### PR TITLE
Fix/inline-dupeInitialization

### DIFF
--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -240,6 +240,10 @@ class SurfaceEmbed {
     const target_client_divs = this.inline_embed_references;
 
     target_client_divs.forEach((client_div) => {
+      if (client_div.querySelector('#surface-inline-div')) {
+        return;
+      }
+      
       const surface_inline_iframe_wrapper = document.createElement("div");
       surface_inline_iframe_wrapper.id = "surface-inline-div";
 

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -135,6 +135,7 @@ class SurfaceEmbed {
         this.embedSurfaceForm = this.embedInline;
         this.shouldShowSurfaceForm = this.showSurfaceInline;
         this.hideSurfaceForm = this.hideSurfaceInline;
+        this.initializeMessageListenerAndEmbed();
       } else if (
         this.embed_type === "popup" ||
         this.embed_type === "widget" ||

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -982,7 +982,6 @@ class SurfaceEmbed {
           this.updateIframeWithOptions(options, this.surface_popup_reference);
           if (!this.initialized) {
             this.initializeMessageListenerAndEmbed();
-
           }
           this.showSurfaceForm();
         }

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -11,8 +11,7 @@ class SurfaceStore {
     this.surfaceDomains = [
       "https://forms.withsurface.com",
       "https://app.withsurface.com",
-      "https://dev.withsurface.com",
-      "https://surfaceforms-git-eng-1695-surface-iframe-post-me-641b21-surface.vercel.app"
+      "https://dev.withsurface.com"
     ];
   }
 
@@ -981,6 +980,9 @@ class SurfaceEmbed {
           ];
           SurfaceTagStore.notifyIframe();
           this.updateIframeWithOptions(options, this.surface_popup_reference);
+          if (!this.initialized) {
+            this.initialize();
+          }
           this.showSurfaceForm();
         }
       } else {
@@ -995,9 +997,6 @@ class SurfaceEmbed {
       }
     };
     if (e && t) {
-      if (!this.initialized) {
-        this.initialize();
-      }
       t.addEventListener("submit", handleSubmitCallback);
 
       t.addEventListener("keydown", handleKeyDownCallback);

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -199,7 +199,7 @@ class SurfaceEmbed {
       );
       if (clickedButton) {
         if (!this.initialized) {
-          this.initialize();
+          this.initializeMessageListenerAndEmbed();
           this.shouldShowSurfaceForm();
         } else {
           this.shouldShowSurfaceForm();
@@ -208,7 +208,7 @@ class SurfaceEmbed {
     });
   }
 
-  initialize() {
+  initializeMessageListenerAndEmbed() {
     if (this.initialized) return;
     window.addEventListener("message", (event) => {
       if (event.origin) {
@@ -606,7 +606,7 @@ class SurfaceEmbed {
     // Clicking the widget button opens the popup
     widgetButton.addEventListener("click", () => {
       if (!this.initialized) {
-        this.initialize();
+        this.initializeMessageListenerAndEmbed();
       }
       this.showSurfaceForm();
     });
@@ -981,7 +981,7 @@ class SurfaceEmbed {
           SurfaceTagStore.notifyIframe();
           this.updateIframeWithOptions(options, this.surface_popup_reference);
           if (!this.initialized) {
-            this.initialize();
+            this.initializeMessageListenerAndEmbed();
           }
           this.showSurfaceForm();
         }
@@ -1006,7 +1006,7 @@ class SurfaceEmbed {
   // Show Surface Form
   showSurfaceForm() {
     if (!this.initialized) {
-      this.initialize();
+      this.initializeMessageListenerAndEmbed();
     }
     // Only update iframe options if we have new data to send
     if (Object.keys(this.options).length > 0) {
@@ -1015,7 +1015,7 @@ class SurfaceEmbed {
     this.shouldShowSurfaceForm();
   }
 
-  // Add getter/setter for popupSize
+  // getter/setter for popupSize
   get popupSize() {
     return this._popupSize;
   }

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -240,6 +240,10 @@ class SurfaceEmbed {
     const target_client_divs = this.inline_embed_references;
 
     target_client_divs.forEach((client_div) => {
+      if (client_div.querySelector('#surface-inline-div')) {
+        return;
+      }
+      
       const surface_inline_iframe_wrapper = document.createElement("div");
       surface_inline_iframe_wrapper.id = "surface-inline-div";
 

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -135,6 +135,7 @@ class SurfaceEmbed {
         this.embedSurfaceForm = this.embedInline;
         this.shouldShowSurfaceForm = this.showSurfaceInline;
         this.hideSurfaceForm = this.hideSurfaceInline;
+        this.initializeMessageListenerAndEmbed();
       } else if (
         this.embed_type === "popup" ||
         this.embed_type === "widget" ||

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -11,8 +11,7 @@ class SurfaceStore {
     this.surfaceDomains = [
       "https://forms.withsurface.com",
       "https://app.withsurface.com",
-      "https://dev.withsurface.com",
-      "https://surfaceforms-git-eng-1695-surface-iframe-post-me-641b21-surface.vercel.app"
+      "https://dev.withsurface.com"
     ];
   }
 
@@ -981,6 +980,9 @@ class SurfaceEmbed {
           ];
           SurfaceTagStore.notifyIframe();
           this.updateIframeWithOptions(options, this.surface_popup_reference);
+          if (!this.initialized) {
+            this.initialize();
+          }
           this.showSurfaceForm();
         }
       } else {
@@ -995,9 +997,6 @@ class SurfaceEmbed {
       }
     };
     if (e && t) {
-      if (!this.initialized) {
-        this.initialize();
-      }
       t.addEventListener("submit", handleSubmitCallback);
 
       t.addEventListener("keydown", handleKeyDownCallback);

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -199,7 +199,7 @@ class SurfaceEmbed {
       );
       if (clickedButton) {
         if (!this.initialized) {
-          this.initialize();
+          this.initializeMessageListenerAndEmbed();
           this.shouldShowSurfaceForm();
         } else {
           this.shouldShowSurfaceForm();
@@ -208,7 +208,7 @@ class SurfaceEmbed {
     });
   }
 
-  initialize() {
+  initializeMessageListenerAndEmbed() {
     if (this.initialized) return;
     window.addEventListener("message", (event) => {
       if (event.origin) {
@@ -606,7 +606,7 @@ class SurfaceEmbed {
     // Clicking the widget button opens the popup
     widgetButton.addEventListener("click", () => {
       if (!this.initialized) {
-        this.initialize();
+        this.initializeMessageListenerAndEmbed();
       }
       this.showSurfaceForm();
     });
@@ -981,7 +981,7 @@ class SurfaceEmbed {
           SurfaceTagStore.notifyIframe();
           this.updateIframeWithOptions(options, this.surface_popup_reference);
           if (!this.initialized) {
-            this.initialize();
+            this.initializeMessageListenerAndEmbed();
           }
           this.showSurfaceForm();
         }
@@ -1006,7 +1006,7 @@ class SurfaceEmbed {
   // Show Surface Form
   showSurfaceForm() {
     if (!this.initialized) {
-      this.initialize();
+      this.initializeMessageListenerAndEmbed();
     }
     // Only update iframe options if we have new data to send
     if (Object.keys(this.options).length > 0) {
@@ -1015,7 +1015,7 @@ class SurfaceEmbed {
     this.shouldShowSurfaceForm();
   }
 
-  // Add getter/setter for popupSize
+  // getter/setter for popupSize
   get popupSize() {
     return this._popupSize;
   }


### PR DESCRIPTION
This PR fixed InLine Embed Type Duplicate Initialization.

## Problem

inline embed type is being initialized twice:
1. Once during construction when initializeMessageListenerAndEmbed() is called directly for inline embeds
2. Again when the click handler or other triggers call initializeMessageListenerAndEmbed()

## Solution

Added a check at the start of embedInline to prevent double embedding