### PR TITLE
Fix Partial Response Tracking

### DIFF
--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -141,6 +141,11 @@ class SurfaceExternalForm {
       const surfaceNextButtonElements = document.getElementsByClassName(
         "surface-next-button"
       );
+
+      const surfaceSubmitButtonElements = document.getElementsByClassName(
+        "surface-submit-button"
+      );
+
       if (surfaceNextButtonElements.length > 0) {
         Array.from(surfaceNextButtonElements).forEach((button) => {
           button.addEventListener("click", (event) => {
@@ -149,11 +154,19 @@ class SurfaceExternalForm {
         });
       }
 
-      form.addEventListener("submit", (event) => {
-        event.preventDefault();
-        this.log(`Form ${formId} submitted`);
-        this.submitForm(form, true);
-      });
+      if (surfaceSubmitButtonElements.length > 0) {
+        Array.from(surfaceSubmitButtonElements).forEach((button) => {
+          button.addEventListener("click", (event) => {
+            this.submitForm(form, true);
+          });
+        });
+      } else {
+        form.addEventListener("submit", (event) => {
+          event.preventDefault();
+          this.log(`Form ${formId} submitted`);
+          this.submitForm(form, true);
+        });
+      }
     });
   }
 }

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -141,6 +141,11 @@ class SurfaceExternalForm {
       const surfaceNextButtonElements = document.getElementsByClassName(
         "surface-next-button"
       );
+
+      const surfaceSubmitButtonElements = document.getElementsByClassName(
+        "surface-submit-button"
+      );
+
       if (surfaceNextButtonElements.length > 0) {
         Array.from(surfaceNextButtonElements).forEach((button) => {
           button.addEventListener("click", (event) => {
@@ -149,11 +154,19 @@ class SurfaceExternalForm {
         });
       }
 
-      form.addEventListener("submit", (event) => {
-        event.preventDefault();
-        this.log(`Form ${formId} submitted`);
-        this.submitForm(form, true);
-      });
+      if (surfaceSubmitButtonElements.length > 0) {
+        Array.from(surfaceSubmitButtonElements).forEach((button) => {
+          button.addEventListener("click", (event) => {
+            this.submitForm(form, true);
+          });
+        });
+      } else {
+        form.addEventListener("submit", (event) => {
+          event.preventDefault();
+          this.log(`Form ${formId} submitted`);
+          this.submitForm(form, true);
+        });
+      }
     });
   }
 }


### PR DESCRIPTION
Fixed Partial Response Tracking

Why this happened:
1. Sometimes if the submit button is wrapped in a div, we're unable to set that submit request

Solution:
1. We have added `suface-submit-button` on the submit button, hence if that is available then it will add a event listener over submit button and `onClick` triggers submit response.