### PR TITLE
ENG 1770 Add Support To Change Embed Types on Breakpoint Change

### DIFF
--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -386,15 +386,15 @@ class SurfaceEmbed {
   getCurrentScreenBreakpoint() {
     const width = window.innerWidth;
     const breakpoints = [
-      { name: "sm", min: 0, max: 640 },
-      { name: "md", min: 640, max: 768 },
-      { name: "lg", min: 768, max: 1024 },
-      { name: "xl", min: 1024, max: 1280 },
-      { name: "2xl", min: 1280, max: Infinity },
+      { name: "2xl", min: 1536 },
+      { name: "xl", min: 1280 },
+      { name: "lg", min: 1024 },
+      { name: "md", min: 768 },
+      { name: "sm", min: 0 },
     ];
 
-    const match = breakpoints.find((bp) => width >= bp.min && width < bp.max);
-    return [match.name, match.min];
+    const matchingBreakpoint = breakpoints.find((bp) => width >= bp.min);
+    return [matchingBreakpoint.name, matchingBreakpoint.min];
   }
 
   log(level, message) {

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -167,7 +167,7 @@ class SurfaceStore {
     this.metadata = {};
     this.partialFilledData = {};
     this.breakpoints = {
-      sm: 640,
+      sm: 0,
       md: 768,
       lg: 1024,
       xl: 1280,

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -166,13 +166,6 @@ class SurfaceStore {
     this.cookies = {};
     this.metadata = {};
     this.partialFilledData = {};
-    this.breakpoints = {
-      sm: 0,
-      md: 768,
-      lg: 1024,
-      xl: 1280,
-      "2xl": 1536,
-    };
     this.debugMode = window.location.search.includes("surfaceDebug=true");
     this.surfaceDomains = [
       "https://forms.withsurface.com",
@@ -383,13 +376,17 @@ class SurfaceEmbed {
   }
 
   findMatchingBreakpoint() {
-    const sortedBreakpoints = Object.entries(SurfaceTagStore.breakpoints).sort(
-      ([, a], [, b]) => b - a
-    );
-
-    return sortedBreakpoints.find(
-      ([, breakpoint]) => window.innerWidth >= breakpoint
-    );
+    const width = window.innerWidth;
+    const breakpoints = [
+      { name: "sm", min: 0, max: 640 },
+      { name: "md", min: 640, max: 768 },
+      { name: "lg", min: 768, max: 1024 },
+      { name: "xl", min: 1024, max: 1280 },
+      { name: "2xl", min: 1280, max: Infinity }
+    ];
+    
+    const match = breakpoints.find(bp => width >= bp.min && width < bp.max);
+    return [match.name, match.min];
   }
 
   log(level, message) {

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -166,6 +166,13 @@ class SurfaceStore {
     this.cookies = {};
     this.metadata = {};
     this.partialFilledData = {};
+    this.validEmbedTypes = [
+      "popup",
+      "slideover",
+      "widget",
+      "inline",
+      "input-trigger",
+    ];
     this.debugMode = window.location.search.includes("surfaceDebug=true");
     this.surfaceDomains = [
       "https://forms.withsurface.com",
@@ -277,12 +284,13 @@ class SurfaceEmbed {
     this.options.popupSize = this._popupSize;
     this.shouldShowSurfaceForm = () => {};
     this.embedSurfaceForm = () => {};
+
+    if (!SurfaceTagStore.validEmbedTypes.includes(this.embed_type)) {
+      this.log("error", "Invalid embed type: must be string or object");
+    }
+
     if (
-      (this.embed_type === "popup" ||
-        this.embed_type === "slideover" ||
-        this.embed_type === "widget" ||
-        this.embed_type === "inline" ||
-        this.embed_type === "input-trigger") &&
+      SurfaceTagStore.validEmbedTypes.includes(this.embed_type) &&
       target_element_class
     ) {
       if (this.embed_type === "inline") {
@@ -340,7 +348,7 @@ class SurfaceEmbed {
 
   handleObjectEmbedType(embed_type) {
     const embedTypeWithDefault = this.ensureDefaultEmbedType(embed_type);
-    const matchingBreakpoint = this.findMatchingBreakpoint();
+    const matchingBreakpoint = this.getCurrentScreenBreakpoint();
 
     if (!matchingBreakpoint) {
       this.log(
@@ -375,17 +383,17 @@ class SurfaceEmbed {
     return embed_type;
   }
 
-  findMatchingBreakpoint() {
+  getCurrentScreenBreakpoint() {
     const width = window.innerWidth;
     const breakpoints = [
       { name: "sm", min: 0, max: 640 },
       { name: "md", min: 640, max: 768 },
       { name: "lg", min: 768, max: 1024 },
       { name: "xl", min: 1024, max: 1280 },
-      { name: "2xl", min: 1280, max: Infinity }
+      { name: "2xl", min: 1280, max: Infinity },
     ];
-    
-    const match = breakpoints.find(bp => width >= bp.min && width < bp.max);
+
+    const match = breakpoints.find((bp) => width >= bp.min && width < bp.max);
     return [match.name, match.min];
   }
 

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -386,15 +386,15 @@ class SurfaceEmbed {
   getCurrentScreenBreakpoint() {
     const width = window.innerWidth;
     const breakpoints = [
-      { name: "sm", min: 0, max: 640 },
-      { name: "md", min: 640, max: 768 },
-      { name: "lg", min: 768, max: 1024 },
-      { name: "xl", min: 1024, max: 1280 },
-      { name: "2xl", min: 1280, max: Infinity },
+      { name: "2xl", min: 1536 },
+      { name: "xl", min: 1280 },
+      { name: "lg", min: 1024 },
+      { name: "md", min: 768 },
+      { name: "sm", min: 0 },
     ];
 
-    const match = breakpoints.find((bp) => width >= bp.min && width < bp.max);
-    return [match.name, match.min];
+    const matchingBreakpoint = breakpoints.find((bp) => width >= bp.min);
+    return [matchingBreakpoint.name, matchingBreakpoint.min];
   }
 
   log(level, message) {

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -167,7 +167,7 @@ class SurfaceStore {
     this.metadata = {};
     this.partialFilledData = {};
     this.breakpoints = {
-      sm: 640,
+      sm: 0,
       md: 768,
       lg: 1024,
       xl: 1280,

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -166,13 +166,6 @@ class SurfaceStore {
     this.cookies = {};
     this.metadata = {};
     this.partialFilledData = {};
-    this.breakpoints = {
-      sm: 0,
-      md: 768,
-      lg: 1024,
-      xl: 1280,
-      "2xl": 1536,
-    };
     this.debugMode = window.location.search.includes("surfaceDebug=true");
     this.surfaceDomains = [
       "https://forms.withsurface.com",
@@ -383,13 +376,17 @@ class SurfaceEmbed {
   }
 
   findMatchingBreakpoint() {
-    const sortedBreakpoints = Object.entries(SurfaceTagStore.breakpoints).sort(
-      ([, a], [, b]) => b - a
-    );
-
-    return sortedBreakpoints.find(
-      ([, breakpoint]) => window.innerWidth >= breakpoint
-    );
+    const width = window.innerWidth;
+    const breakpoints = [
+      { name: "sm", min: 0, max: 640 },
+      { name: "md", min: 640, max: 768 },
+      { name: "lg", min: 768, max: 1024 },
+      { name: "xl", min: 1024, max: 1280 },
+      { name: "2xl", min: 1280, max: Infinity }
+    ];
+    
+    const match = breakpoints.find(bp => width >= bp.min && width < bp.max);
+    return [match.name, match.min];
   }
 
   log(level, message) {

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -166,6 +166,13 @@ class SurfaceStore {
     this.cookies = {};
     this.metadata = {};
     this.partialFilledData = {};
+    this.validEmbedTypes = [
+      "popup",
+      "slideover",
+      "widget",
+      "inline",
+      "input-trigger",
+    ];
     this.debugMode = window.location.search.includes("surfaceDebug=true");
     this.surfaceDomains = [
       "https://forms.withsurface.com",
@@ -277,12 +284,13 @@ class SurfaceEmbed {
     this.options.popupSize = this._popupSize;
     this.shouldShowSurfaceForm = () => {};
     this.embedSurfaceForm = () => {};
+
+    if (!SurfaceTagStore.validEmbedTypes.includes(this.embed_type)) {
+      this.log("error", "Invalid embed type: must be string or object");
+    }
+
     if (
-      (this.embed_type === "popup" ||
-        this.embed_type === "slideover" ||
-        this.embed_type === "widget" ||
-        this.embed_type === "inline" ||
-        this.embed_type === "input-trigger") &&
+      SurfaceTagStore.validEmbedTypes.includes(this.embed_type) &&
       target_element_class
     ) {
       if (this.embed_type === "inline") {
@@ -340,7 +348,7 @@ class SurfaceEmbed {
 
   handleObjectEmbedType(embed_type) {
     const embedTypeWithDefault = this.ensureDefaultEmbedType(embed_type);
-    const matchingBreakpoint = this.findMatchingBreakpoint();
+    const matchingBreakpoint = this.getCurrentScreenBreakpoint();
 
     if (!matchingBreakpoint) {
       this.log(
@@ -375,17 +383,17 @@ class SurfaceEmbed {
     return embed_type;
   }
 
-  findMatchingBreakpoint() {
+  getCurrentScreenBreakpoint() {
     const width = window.innerWidth;
     const breakpoints = [
       { name: "sm", min: 0, max: 640 },
       { name: "md", min: 640, max: 768 },
       { name: "lg", min: 768, max: 1024 },
       { name: "xl", min: 1024, max: 1280 },
-      { name: "2xl", min: 1280, max: Infinity }
+      { name: "2xl", min: 1280, max: Infinity },
     ];
-    
-    const match = breakpoints.find(bp => width >= bp.min && width < bp.max);
+
+    const match = breakpoints.find((bp) => width >= bp.min && width < bp.max);
     return [match.name, match.min];
   }
 


### PR DESCRIPTION
Add Support to change the Embed Type of Surface Form when BreakPoint Change.

> [!NOTE]  
> This feature won't run on dynamic screen size change, as we didn't add any observer to the script -- hence user have to refresh the page to see changes.

### Overview
1. Extended functionality of adding breakpoints (similar to tailwind) to embed type variable.

```javascript
const surface_embed_type = {
          default: "slideover",
          sm: "widget",
          md: "slideover",
          lg: "popup",
          xl: "popup",
          "2xl": "slideover"
        };
```

2. Backward Support:

```javascript
const surface_embed_type = "slideover";
```

### Testing
- [x] Fallback to default type if user haven't specified certain breakpoint
- [x] All embedding types should be working: `popup`, `slideover` and `widget`
- [x] Backward compatible to old implementation: `const surface_embed_type = "slideover"`

### Loom Video
https://www.loom.com/share/d535c4dfe10543fe8f90025fa7ac05bd