### PR TITLE
fix: Identity API error

### DIFF
--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -91,6 +91,8 @@ class SurfaceExternalForm {
       sourceURLDomain: parentUrl.hostname,
       sourceURLPath: parentUrl.pathname,
       sourceUrlSearchParams: parentUrl.search,
+      leadId: null,
+      sessionIdFromParams: null
     };
     try {
       const identifyResponse = await fetch(apiUrl, {

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -91,6 +91,8 @@ class SurfaceExternalForm {
       sourceURLDomain: parentUrl.hostname,
       sourceURLPath: parentUrl.pathname,
       sourceUrlSearchParams: parentUrl.search,
+      leadId: null,
+      sessionIdFromParams: null
     };
     try {
       const identifyResponse = await fetch(apiUrl, {


### PR DESCRIPTION
This PR fixes the following issue with Identity Info API.
- [x] Lead Id is not required
- [x] Lead session Id is also not required