### PR TITLE
Added support for multiple input triggers

### DIFF
--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -92,7 +92,7 @@ class SurfaceExternalForm {
       sourceURLPath: parentUrl.pathname,
       sourceUrlSearchParams: parentUrl.search,
       leadId: null,
-      sessionIdFromParams: null
+      sessionIdFromParams: null,
     };
     try {
       const identifyResponse = await fetch(apiUrl, {
@@ -240,7 +240,9 @@ class SurfaceExternalForm {
       this.log(`Attaching handlers to form: ${formId}`);
 
       form
-        .querySelectorAll("input[data-id], select[data-id], textarea[data-id], fieldset[data-id]")
+        .querySelectorAll(
+          "input[data-id], select[data-id], textarea[data-id], fieldset[data-id]"
+        )
         .forEach((element) =>
           element.addEventListener("change", (e) =>
             this.handleInputChange(formId, e)
@@ -261,7 +263,7 @@ class SurfaceExternalForm {
             this.submitForm(form, false);
           });
         });
-      } 
+      }
       if (surfaceSubmitButtonElements.length > 0) {
         Array.from(surfaceSubmitButtonElements).forEach((button) => {
           button.addEventListener("click", (event) => {
@@ -1358,11 +1360,6 @@ class SurfaceEmbed {
     const handleKeyDownCallback = (t) => (n) => {
       if (n.key === "Enter" && document.activeElement.type === "email") {
         n.preventDefault();
-        const value = n.target.value;
-        const triggers = document.querySelectorAll(".surface-form-handler");
-        triggers.forEach((t) => {
-          t.querySelector('input[type="email"]').value = value;
-        });
 
         t.dispatchEvent(new Event("submit", { cancelable: true }));
       }

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -92,7 +92,7 @@ class SurfaceExternalForm {
       sourceURLPath: parentUrl.pathname,
       sourceUrlSearchParams: parentUrl.search,
       leadId: null,
-      sessionIdFromParams: null
+      sessionIdFromParams: null,
     };
     try {
       const identifyResponse = await fetch(apiUrl, {
@@ -240,7 +240,9 @@ class SurfaceExternalForm {
       this.log(`Attaching handlers to form: ${formId}`);
 
       form
-        .querySelectorAll("input[data-id], select[data-id], textarea[data-id], fieldset[data-id]")
+        .querySelectorAll(
+          "input[data-id], select[data-id], textarea[data-id], fieldset[data-id]"
+        )
         .forEach((element) =>
           element.addEventListener("change", (e) =>
             this.handleInputChange(formId, e)
@@ -261,7 +263,7 @@ class SurfaceExternalForm {
             this.submitForm(form, false);
           });
         });
-      } 
+      }
       if (surfaceSubmitButtonElements.length > 0) {
         Array.from(surfaceSubmitButtonElements).forEach((button) => {
           button.addEventListener("click", (event) => {
@@ -1358,11 +1360,6 @@ class SurfaceEmbed {
     const handleKeyDownCallback = (t) => (n) => {
       if (n.key === "Enter" && document.activeElement.type === "email") {
         n.preventDefault();
-        const value = n.target.value;
-        const triggers = document.querySelectorAll(".surface-form-handler");
-        triggers.forEach((t) => {
-          t.querySelector('input[type="email"]').value = value;
-        });
 
         t.dispatchEvent(new Event("submit", { cancelable: true }));
       }


### PR DESCRIPTION
> [!NOTE]
> Successfully tested on WebFlow: https://www.loom.com/share/be275b7807044577b443be950b614527

## Overview

This PR adds support to let users add more than one input triggers.

## Testing 

- [ ] Create a webpage with 2 input triggers. follow this: https://docs.withsurface.com/developers/surface-forms/email-trigger
- [ ] The form should trigger from while submitting any of the input trigger

## Loom

https://www.loom.com/share/00f4ed14e7444dc4b00820614532a11c