### PR TITLE
Add support for work email in input trigger embedding

### DIFF
--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -1381,6 +1381,13 @@ class SurfaceEmbed {
     const e = document
       .querySelector("[data-question-id]")
       ?.getAttribute("data-question-id");
+
+    const isWorkEmailOnly = document
+      .querySelector("[data-question-id]")
+      ?.getAttribute("data-work-email-only");
+
+    const emailKey = isWorkEmailOnly ? "workEmailAddress" : "emailAddress";
+
     const forms = document.querySelectorAll("form.surface-form-handler");
 
     const handleSubmitCallback = (t) => (n) => {
@@ -1388,7 +1395,7 @@ class SurfaceEmbed {
       const o = t.querySelector('input[type="email"]'),
         c = o?.value.trim();
       if (o && /^[^\s@]+@[^\s@]+\.[a-zA-Z]{2,}$/.test(c)) {
-        const options = { [`${e}_emailAddress`]: c };
+        const options = { [`${e}_${emailKey}`]: c };
         if (options) {
           const existingData = Array.isArray(SurfaceTagStore.partialFilledData)
             ? SurfaceTagStore.partialFilledData

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -1381,6 +1381,13 @@ class SurfaceEmbed {
     const e = document
       .querySelector("[data-question-id]")
       ?.getAttribute("data-question-id");
+
+    const isWorkEmailOnly = document
+      .querySelector("[data-question-id]")
+      ?.getAttribute("data-work-email-only");
+
+    const emailKey = isWorkEmailOnly ? "workEmailAddress" : "emailAddress";
+
     const forms = document.querySelectorAll("form.surface-form-handler");
 
     const handleSubmitCallback = (t) => (n) => {
@@ -1388,7 +1395,7 @@ class SurfaceEmbed {
       const o = t.querySelector('input[type="email"]'),
         c = o?.value.trim();
       if (o && /^[^\s@]+@[^\s@]+\.[a-zA-Z]{2,}$/.test(c)) {
-        const options = { [`${e}_emailAddress`]: c };
+        const options = { [`${e}_${emailKey}`]: c };
         if (options) {
           const existingData = Array.isArray(SurfaceTagStore.partialFilledData)
             ? SurfaceTagStore.partialFilledData


### PR DESCRIPTION
## What does this PR do?

Added support for work email, in input trigger embedding 

## Testing

To test, we need a local project setup with surface tag and email input trigger

- [ ] Add identity info with work email address only in form and link to project
- [ ] add `data-work-email-only="true"` attribute in your tag
- [ ] this should block any personal emails from being submitted in form.
