### PR TITLE
Remove website de-anonymisation (5x5/usbrowserspeed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .playwright-mcp/
+test.html

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -1,71 +1,7 @@
 const SURFACE_USER_JOURNEY_COOKIE_NAME = "surface_journey_id";
 const SURFACE_USER_JOURNEY_RECENT_VISIT_COOKIE_NAME = "surface_recent_visit";
 
-let SurfaceUsBrowserSpeedInitialized = false;
-let SurfaceSharedSessionId = null;
 let EnvironmentId = null;
-let LeadIdentifyInProgress = null;
-
-async function getHash(input) {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(input);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashHex = hashArray
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return hashHex;
-}
-
-//To generate fingerprint for the lead
-const getBrowserFingerprint = async (environmentId) => {
-  let fingerprint = {};
-
-  // Device Type
-  fingerprint.deviceType = /Mobi|Android/i.test(navigator.userAgent)
-    ? "Mobile"
-    : "Desktop";
-
-  // Screen Properties
-  fingerprint.screen = {
-    width: screen.width,
-    height: screen.height,
-    colorDepth: screen.colorDepth,
-  };
-
-  // Browser, OS, and Version
-  fingerprint.userAgent = navigator.userAgent;
-
-  //@ts-ignore
-  let userAgentData = navigator.userAgentData || {};
-
-  fingerprint.browser = userAgentData.brands ||
-    userAgentData.uaList || [{ brand: "unknown", version: "unknown" }];
-  fingerprint.os = userAgentData.platform || "unknown";
-
-  // Browser Language
-  fingerprint.language = navigator.language;
-
-  // Installed Plugins
-  if (navigator.plugins != null) {
-    fingerprint.plugins = Array.from(navigator.plugins).map(
-      (plugin) => plugin.name
-    );
-  }
-
-  // Time Zone
-  fingerprint.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-  fingerprint.environmentId = environmentId;
-
-  // Combine all fingerprint data into a single string
-  let fingerprintString = JSON.stringify(fingerprint);
-
-  // Generate a unique ID using a hash function
-  fingerprint.id = await getHash(fingerprintString);
-
-  return fingerprint;
-};
 
 // Helper function to get site ID from script tag with multiple attribute name variations
 function SurfaceGetSiteIdFromScript(scriptElement) {
@@ -83,206 +19,6 @@ function SurfaceGetSiteIdFromScript(scriptElement) {
   return null;
 }
 
-// ========================================
-// START OF DE-ANONYMIZATION CODE
-// ========================================
-
-// Generate a unique session ID for comparison between services
-function SurfaceGenerateSessionId() {
-  if (!SurfaceSharedSessionId) {
-    SurfaceSharedSessionId =
-      "session_" +
-      Math.random().toString(36).substring(2, 15) +
-      Math.random().toString(36).substring(2, 15);
-  }
-  return SurfaceSharedSessionId;
-}
-
-function SurfaceSetLeadDataWithTTL({
-  leadId,
-  leadSessionId,
-  fingerprint,
-  landingPageUrl,
-}) {
-  const ttl = 10 * 60 * 1000; // 10 minutes in milliseconds
-  const item = {
-    leadId: leadId,
-    leadSessionId: leadSessionId,
-    fingerprint,
-    expiry: new Date().getTime() + ttl,
-    landingPageUrl,
-  };
-  localStorage.setItem("surfaceLeadData", JSON.stringify(item));
-}
-
-function SurfaceGetLeadDataWithTTL() {
-  const itemStr = localStorage.getItem("surfaceLeadData");
-
-  if (!itemStr) {
-    return null;
-  }
-
-  try {
-    const item = JSON.parse(itemStr);
-    const now = new Date().getTime();
-
-    // Check if expired
-    if (now > item.expiry) {
-      localStorage.removeItem("surfaceLeadData");
-      return null;
-    }
-
-    return {
-      leadId: item?.leadId,
-      leadSessionId: item?.leadSessionId,
-      fingerprint: item?.fingerprint,
-      landingPageUrl: item?.landingPageUrl,
-      expiry: item.expiry,
-    };
-  } catch (error) {
-    console.error("Error parsing lead data from localStorage:", error);
-    return null;
-  }
-}
-
-// Identify function to get lead information
-async function SurfaceIdentifyLead(environmentId) {
-  // If a call is already in progress, wait for it to complete
-  if (LeadIdentifyInProgress) {
-    // Poll for cached data with timeout
-    const maxWaitTime = 5000; // 5 seconds max wait
-    const pollInterval = 100; // Check every 100ms
-    const startTime = Date.now();
-
-    while (LeadIdentifyInProgress && Date.now() - startTime < maxWaitTime) {
-      await new Promise((resolve) => setTimeout(resolve, pollInterval));
-
-      // Check if data is now available in cache
-      const cachedData = SurfaceGetLeadDataWithTTL();
-      if (cachedData && cachedData.leadSessionId && cachedData.fingerprint) {
-        return {
-          leadId: cachedData.leadId,
-          leadSessionId: cachedData.leadSessionId,
-          fingerprint: cachedData.fingerprint,
-        };
-      }
-    }
-  }
-
-  // Check if we have valid cached data first
-  const cachedData = SurfaceGetLeadDataWithTTL();
-  const now = new Date().getTime();
-
-  if (
-    cachedData &&
-    cachedData.leadSessionId &&
-    cachedData.fingerprint &&
-    now < cachedData.expiry
-  ) {
-    return {
-      leadId: cachedData.leadId,
-      leadSessionId: cachedData.leadSessionId,
-      fingerprint: cachedData.fingerprint,
-    };
-  }
-
-  // Set flag before making API call
-  LeadIdentifyInProgress = true;
-
-  const fingerprint = await getBrowserFingerprint(environmentId);
-  const apiUrl = "https://forms.withsurface.com/api/v1/lead/identify";
-  const parentUrl = new URL(window.location.href);
-
-  const payload = {
-    fingerprint: fingerprint.id,
-    environmentId: environmentId,
-    source: "website",
-    sourceURL: parentUrl.href,
-    sourceURLDomain: parentUrl.hostname,
-    sourceURLPath: parentUrl.pathname,
-    sourceUrlSearchParams: parentUrl.search,
-    leadId: cachedData?.leadId,
-    sessionIdFromParams: cachedData?.leadSessionId,
-  };
-
-  try {
-    const identifyResponse = await fetch(apiUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    });
-
-    const jsonData = await identifyResponse.json();
-
-    if (identifyResponse.ok && jsonData.data && jsonData.data.data) {
-      const leadId = jsonData.data.data.leadId || null;
-      const leadSessionId = jsonData.data.data.sessionId || null;
-
-      // Store in localStorage with TTL
-      SurfaceSetLeadDataWithTTL({
-        leadId,
-        leadSessionId,
-        fingerprint: fingerprint.id,
-        landingPageUrl: window.location.href,
-      });
-
-      return {
-        leadId: leadId,
-        leadSessionId: leadSessionId,
-        fingerprint: fingerprint.id,
-      };
-    }
-  } catch (error) {
-    console.error("Error identifying lead:", error);
-  } finally {
-    LeadIdentifyInProgress = false;
-  }
-
-  // Reset flag on failure too
-  LeadIdentifyInProgress = false;
-  return null;
-}
-
-// Send payload to 5x5
-function SurfaceSendToFiveByFive(payload) {
-  const endpoint = new URL("https://a.usbrowserspeed.com/cs");
-  var pid = "b3752b5f7f17d773b265c2847b23ffa444cac7db2af8a040c341973a6704a819";
-  endpoint.searchParams.append("pid", pid);
-  endpoint.searchParams.append("puid", JSON.stringify(payload));
-
-  fetch(endpoint.href, {
-    mode: "no-cors",
-    credentials: "include",
-  });
-  SurfaceUsBrowserSpeedInitialized = true;
-}
-
-async function SurfaceSyncCookie(payload) {
-  const sessionId = SurfaceGenerateSessionId();
-
-  // Add session ID to payload for both services
-  const enhancedPayload = Object.assign({}, payload, {
-    type: "LogAnonLeadEnvIdPayload",
-    sessionId: sessionId,
-  });
-
-  if (SurfaceUsBrowserSpeedInitialized == false) {
-    // Call identify first to get lead data
-    const leadData = await SurfaceIdentifyLead(payload.environmentId);
-    SurfaceTagStore.sendPayloadToIframes("LEAD_DATA_UPDATE");
-
-    // Send to usbrowserspeed with lead data
-    SurfaceSendToFiveByFive({
-      ...enhancedPayload,
-      ...(leadData ? leadData : {}),
-    });
-  }
-}
-// ========================================
-// END OF DE-ANONYMIZATION CODE
-// ========================================
 
 class SurfaceExternalForm {
   constructor(props) {
@@ -600,11 +336,7 @@ class SurfaceStore {
     this.userJourney = [];
 
     this._initializeMessageListener();
-    this.cachedIdentifyData = SurfaceGetLeadDataWithTTL();
-    if (
-      (this.cachedIdentifyData || LeadIdentifyInProgress !== true) &&
-      !this._isCurrentOriginSurfaceDomain()
-    ) {
+    if (!this._isCurrentOriginSurfaceDomain()) {
       this._initializeUserJourneyTracking();
       this._setupRouteChangeDetection();
     }
@@ -628,15 +360,6 @@ class SurfaceStore {
 
       if (event.data.type === "SEND_DATA") {
         this.sendPayloadToIframes("STORE_UPDATE");
-        if (EnvironmentId) {
-          SurfaceIdentifyLead(EnvironmentId)
-            .then(() => {
-              this.sendPayloadToIframes("LEAD_DATA_UPDATE");
-            })
-            .catch((e) => console.log("Failed identify", e));
-        } else {
-          this.sendPayloadToIframes("LEAD_DATA_UPDATE");
-        }
       }
       if (event.data.event === "CLEAR_USER_JOURNEY_DATA") {
         this.log("info", "Clearing user journey");
@@ -779,7 +502,6 @@ class SurfaceStore {
       origin: this.origin,
       questionIds: this.partialFilledData,
       urlParams: this.urlParams,
-      surfaceLeadData: SurfaceGetLeadDataWithTTL(),
       userJourneyId: this.userJourneyId,
     };
   }
@@ -815,8 +537,6 @@ class SurfaceStore {
         return;
       }
 
-      const surfaceLeadData = SurfaceGetLeadDataWithTTL();
-
       this._trackToRedis({
         data: {
           type: "page_view",
@@ -826,9 +546,7 @@ class SurfaceStore {
             referrer: this.referrer,
           },
         },
-        metadata: {
-          ...(surfaceLeadData ? surfaceLeadData : null),
-        },
+        metadata: {},
       });
 
       this._setCookie(SURFACE_USER_JOURNEY_RECENT_VISIT_COOKIE_NAME, currentUrl, {
@@ -924,8 +642,6 @@ class SurfaceStore {
         return;
       }
 
-      const surfaceLeadData = SurfaceGetLeadDataWithTTL();
-
       this._trackToRedis({
         data: {
           type: "page_view",
@@ -934,9 +650,7 @@ class SurfaceStore {
             timestamp: new Date().toISOString(),
           },
         },
-        metadata: {
-          ...(surfaceLeadData ? surfaceLeadData : null),
-        },
+        metadata: {},
       });
 
       this._setCookie(SURFACE_USER_JOURNEY_RECENT_VISIT_COOKIE_NAME, currentUrl, {
@@ -2477,10 +2191,4 @@ class SurfaceEmbed {
   const environmentId = SurfaceGetSiteIdFromScript(scriptTag);
   EnvironmentId = environmentId;
 
-  if (environmentId != null) {
-    const syncCookiePayload = {
-      environmentId: environmentId,
-    };
-    SurfaceSyncCookie(syncCookiePayload);
-  }
 })();

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -1,71 +1,7 @@
 const SURFACE_USER_JOURNEY_COOKIE_NAME = "surface_journey_id";
 const SURFACE_USER_JOURNEY_RECENT_VISIT_COOKIE_NAME = "surface_recent_visit";
 
-let SurfaceUsBrowserSpeedInitialized = false;
-let SurfaceSharedSessionId = null;
 let EnvironmentId = null;
-let LeadIdentifyInProgress = null;
-
-async function getHash(input) {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(input);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashHex = hashArray
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return hashHex;
-}
-
-//To generate fingerprint for the lead
-const getBrowserFingerprint = async (environmentId) => {
-  let fingerprint = {};
-
-  // Device Type
-  fingerprint.deviceType = /Mobi|Android/i.test(navigator.userAgent)
-    ? "Mobile"
-    : "Desktop";
-
-  // Screen Properties
-  fingerprint.screen = {
-    width: screen.width,
-    height: screen.height,
-    colorDepth: screen.colorDepth,
-  };
-
-  // Browser, OS, and Version
-  fingerprint.userAgent = navigator.userAgent;
-
-  //@ts-ignore
-  let userAgentData = navigator.userAgentData || {};
-
-  fingerprint.browser = userAgentData.brands ||
-    userAgentData.uaList || [{ brand: "unknown", version: "unknown" }];
-  fingerprint.os = userAgentData.platform || "unknown";
-
-  // Browser Language
-  fingerprint.language = navigator.language;
-
-  // Installed Plugins
-  if (navigator.plugins != null) {
-    fingerprint.plugins = Array.from(navigator.plugins).map(
-      (plugin) => plugin.name
-    );
-  }
-
-  // Time Zone
-  fingerprint.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-  fingerprint.environmentId = environmentId;
-
-  // Combine all fingerprint data into a single string
-  let fingerprintString = JSON.stringify(fingerprint);
-
-  // Generate a unique ID using a hash function
-  fingerprint.id = await getHash(fingerprintString);
-
-  return fingerprint;
-};
 
 // Helper function to get site ID from script tag with multiple attribute name variations
 function SurfaceGetSiteIdFromScript(scriptElement) {
@@ -83,206 +19,6 @@ function SurfaceGetSiteIdFromScript(scriptElement) {
   return null;
 }
 
-// ========================================
-// START OF DE-ANONYMIZATION CODE
-// ========================================
-
-// Generate a unique session ID for comparison between services
-function SurfaceGenerateSessionId() {
-  if (!SurfaceSharedSessionId) {
-    SurfaceSharedSessionId =
-      "session_" +
-      Math.random().toString(36).substring(2, 15) +
-      Math.random().toString(36).substring(2, 15);
-  }
-  return SurfaceSharedSessionId;
-}
-
-function SurfaceSetLeadDataWithTTL({
-  leadId,
-  leadSessionId,
-  fingerprint,
-  landingPageUrl,
-}) {
-  const ttl = 10 * 60 * 1000; // 10 minutes in milliseconds
-  const item = {
-    leadId: leadId,
-    leadSessionId: leadSessionId,
-    fingerprint,
-    expiry: new Date().getTime() + ttl,
-    landingPageUrl,
-  };
-  localStorage.setItem("surfaceLeadData", JSON.stringify(item));
-}
-
-function SurfaceGetLeadDataWithTTL() {
-  const itemStr = localStorage.getItem("surfaceLeadData");
-
-  if (!itemStr) {
-    return null;
-  }
-
-  try {
-    const item = JSON.parse(itemStr);
-    const now = new Date().getTime();
-
-    // Check if expired
-    if (now > item.expiry) {
-      localStorage.removeItem("surfaceLeadData");
-      return null;
-    }
-
-    return {
-      leadId: item?.leadId,
-      leadSessionId: item?.leadSessionId,
-      fingerprint: item?.fingerprint,
-      landingPageUrl: item?.landingPageUrl,
-      expiry: item.expiry,
-    };
-  } catch (error) {
-    console.error("Error parsing lead data from localStorage:", error);
-    return null;
-  }
-}
-
-// Identify function to get lead information
-async function SurfaceIdentifyLead(environmentId) {
-  // If a call is already in progress, wait for it to complete
-  if (LeadIdentifyInProgress) {
-    // Poll for cached data with timeout
-    const maxWaitTime = 5000; // 5 seconds max wait
-    const pollInterval = 100; // Check every 100ms
-    const startTime = Date.now();
-
-    while (LeadIdentifyInProgress && Date.now() - startTime < maxWaitTime) {
-      await new Promise((resolve) => setTimeout(resolve, pollInterval));
-
-      // Check if data is now available in cache
-      const cachedData = SurfaceGetLeadDataWithTTL();
-      if (cachedData && cachedData.leadSessionId && cachedData.fingerprint) {
-        return {
-          leadId: cachedData.leadId,
-          leadSessionId: cachedData.leadSessionId,
-          fingerprint: cachedData.fingerprint,
-        };
-      }
-    }
-  }
-
-  // Check if we have valid cached data first
-  const cachedData = SurfaceGetLeadDataWithTTL();
-  const now = new Date().getTime();
-
-  if (
-    cachedData &&
-    cachedData.leadSessionId &&
-    cachedData.fingerprint &&
-    now < cachedData.expiry
-  ) {
-    return {
-      leadId: cachedData.leadId,
-      leadSessionId: cachedData.leadSessionId,
-      fingerprint: cachedData.fingerprint,
-    };
-  }
-
-  // Set flag before making API call
-  LeadIdentifyInProgress = true;
-
-  const fingerprint = await getBrowserFingerprint(environmentId);
-  const apiUrl = "https://forms.withsurface.com/api/v1/lead/identify";
-  const parentUrl = new URL(window.location.href);
-
-  const payload = {
-    fingerprint: fingerprint.id,
-    environmentId: environmentId,
-    source: "website",
-    sourceURL: parentUrl.href,
-    sourceURLDomain: parentUrl.hostname,
-    sourceURLPath: parentUrl.pathname,
-    sourceUrlSearchParams: parentUrl.search,
-    leadId: cachedData?.leadId,
-    sessionIdFromParams: cachedData?.leadSessionId,
-  };
-
-  try {
-    const identifyResponse = await fetch(apiUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    });
-
-    const jsonData = await identifyResponse.json();
-
-    if (identifyResponse.ok && jsonData.data && jsonData.data.data) {
-      const leadId = jsonData.data.data.leadId || null;
-      const leadSessionId = jsonData.data.data.sessionId || null;
-
-      // Store in localStorage with TTL
-      SurfaceSetLeadDataWithTTL({
-        leadId,
-        leadSessionId,
-        fingerprint: fingerprint.id,
-        landingPageUrl: window.location.href,
-      });
-
-      return {
-        leadId: leadId,
-        leadSessionId: leadSessionId,
-        fingerprint: fingerprint.id,
-      };
-    }
-  } catch (error) {
-    console.error("Error identifying lead:", error);
-  } finally {
-    LeadIdentifyInProgress = false;
-  }
-
-  // Reset flag on failure too
-  LeadIdentifyInProgress = false;
-  return null;
-}
-
-// Send payload to 5x5
-function SurfaceSendToFiveByFive(payload) {
-  const endpoint = new URL("https://a.usbrowserspeed.com/cs");
-  var pid = "b3752b5f7f17d773b265c2847b23ffa444cac7db2af8a040c341973a6704a819";
-  endpoint.searchParams.append("pid", pid);
-  endpoint.searchParams.append("puid", JSON.stringify(payload));
-
-  fetch(endpoint.href, {
-    mode: "no-cors",
-    credentials: "include",
-  });
-  SurfaceUsBrowserSpeedInitialized = true;
-}
-
-async function SurfaceSyncCookie(payload) {
-  const sessionId = SurfaceGenerateSessionId();
-
-  // Add session ID to payload for both services
-  const enhancedPayload = Object.assign({}, payload, {
-    type: "LogAnonLeadEnvIdPayload",
-    sessionId: sessionId,
-  });
-
-  if (SurfaceUsBrowserSpeedInitialized == false) {
-    // Call identify first to get lead data
-    const leadData = await SurfaceIdentifyLead(payload.environmentId);
-    SurfaceTagStore.sendPayloadToIframes("LEAD_DATA_UPDATE");
-
-    // Send to usbrowserspeed with lead data
-    SurfaceSendToFiveByFive({
-      ...enhancedPayload,
-      ...(leadData ? leadData : {}),
-    });
-  }
-}
-// ========================================
-// END OF DE-ANONYMIZATION CODE
-// ========================================
 
 class SurfaceExternalForm {
   constructor(props) {
@@ -600,11 +336,7 @@ class SurfaceStore {
     this.userJourney = [];
 
     this._initializeMessageListener();
-    this.cachedIdentifyData = SurfaceGetLeadDataWithTTL();
-    if (
-      (this.cachedIdentifyData || LeadIdentifyInProgress !== true) &&
-      !this._isCurrentOriginSurfaceDomain()
-    ) {
+    if (!this._isCurrentOriginSurfaceDomain()) {
       this._initializeUserJourneyTracking();
       this._setupRouteChangeDetection();
     }
@@ -628,15 +360,6 @@ class SurfaceStore {
 
       if (event.data.type === "SEND_DATA") {
         this.sendPayloadToIframes("STORE_UPDATE");
-        if (EnvironmentId) {
-          SurfaceIdentifyLead(EnvironmentId)
-            .then(() => {
-              this.sendPayloadToIframes("LEAD_DATA_UPDATE");
-            })
-            .catch((e) => console.log("Failed identify", e));
-        } else {
-          this.sendPayloadToIframes("LEAD_DATA_UPDATE");
-        }
       }
       if (event.data.event === "CLEAR_USER_JOURNEY_DATA") {
         this.log("info", "Clearing user journey");
@@ -779,7 +502,6 @@ class SurfaceStore {
       origin: this.origin,
       questionIds: this.partialFilledData,
       urlParams: this.urlParams,
-      surfaceLeadData: SurfaceGetLeadDataWithTTL(),
       userJourneyId: this.userJourneyId,
     };
   }
@@ -815,8 +537,6 @@ class SurfaceStore {
         return;
       }
 
-      const surfaceLeadData = SurfaceGetLeadDataWithTTL();
-
       this._trackToRedis({
         data: {
           type: "page_view",
@@ -826,9 +546,7 @@ class SurfaceStore {
             referrer: this.referrer,
           },
         },
-        metadata: {
-          ...(surfaceLeadData ? surfaceLeadData : null),
-        },
+        metadata: {},
       });
 
       this._setCookie(SURFACE_USER_JOURNEY_RECENT_VISIT_COOKIE_NAME, currentUrl, {
@@ -924,8 +642,6 @@ class SurfaceStore {
         return;
       }
 
-      const surfaceLeadData = SurfaceGetLeadDataWithTTL();
-
       this._trackToRedis({
         data: {
           type: "page_view",
@@ -934,9 +650,7 @@ class SurfaceStore {
             timestamp: new Date().toISOString(),
           },
         },
-        metadata: {
-          ...(surfaceLeadData ? surfaceLeadData : null),
-        },
+        metadata: {},
       });
 
       this._setCookie(SURFACE_USER_JOURNEY_RECENT_VISIT_COOKIE_NAME, currentUrl, {
@@ -2477,10 +2191,4 @@ class SurfaceEmbed {
   const environmentId = SurfaceGetSiteIdFromScript(scriptTag);
   EnvironmentId = environmentId;
 
-  if (environmentId != null) {
-    const syncCookiePayload = {
-      environmentId: environmentId,
-    };
-    SurfaceSyncCookie(syncCookiePayload);
-  }
 })();


### PR DESCRIPTION
## Summary
- Removes the entire FiveByFive/usbrowserspeed de-anonymisation integration (`SurfaceSendToFiveByFive`, `SurfaceIdentifyLead`, `SurfaceSyncCookie`, fingerprinting, localStorage lead caching)
- Cleans up all related global variables, iframe `LEAD_DATA_UPDATE` messages, tracking metadata references, and the `SurfaceSyncCookie` boot call
- **-295 lines**, no functional changes to forms, embeds, or user journey tracking

## Test plan
- [ ] Verify surface tag loads without errors on a test page
- [ ] Confirm no network requests to `usbrowserspeed.com`
- [ ] Verify form submissions and embed rendering still work
- [ ] Verify user journey tracking still fires page views

🤖 Generated with [Claude Code](https://claude.com/claude-code)