### PR TITLE
Track pageviews through identify

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "esbuild src/index.ts --bundle --format=iife --outfile=surface_tag.js --target=es2020 && pnpm copyTagToEmbed",
     "copyTagToEmbed": "cp surface_tag.js surface_embed_v1.js",
     "dev": "esbuild src/index.ts --bundle --format=iife --outfile=surface_tag.js --target=es2020 --watch --sourcemap",
+    "test": "node --test test/content-analytics-pageviews.test.mjs",
     "typecheck": "tsc --noEmit",
     "postbuild": "pnpm copyTagToEmbed"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   getLeadDataWithTTL,
   setEnvironmentId,
 } from "./lead/identify";
+import { initializePageviewTracking } from "./lead/pageview";
 import { SurfaceStore } from "./store/store";
 import { SurfaceExternalForm } from "./external-form/external-form";
 import { SurfaceEmbed } from "./embed/embed";
@@ -27,4 +28,5 @@ w.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
   const scriptTag = document.currentScript as HTMLScriptElement;
   const environmentId = getSiteIdFromScript(scriptTag);
   setEnvironmentId(environmentId);
+  initializePageviewTracking(environmentId);
 })();

--- a/src/lead/identify.ts
+++ b/src/lead/identify.ts
@@ -5,6 +5,11 @@ import type { LeadData } from "../types";
 let environmentId: string | null = null;
 let identifyInProgress = false;
 
+interface IdentifyLeadOptions {
+  forceNetwork?: boolean;
+  sourceUrl?: string;
+}
+
 export function setEnvironmentId(id: string | null): void {
   environmentId = id;
 }
@@ -49,22 +54,33 @@ export function getLeadDataWithTTL(): LeadData | null {
 }
 
 export async function identifyLead(
-  envId: string
+  envId: string,
+  options: IdentifyLeadOptions = {}
 ): Promise<LeadData | null> {
+  if (identifyInProgress) {
+    if (options.forceNetwork) {
+      await waitForIdentifyToFinish();
+    } else {
+      return waitForCachedData();
+    }
+  }
+
   if (identifyInProgress) {
     return waitForCachedData();
   }
 
   const cached = getLeadDataWithTTL();
-  if (cached?.leadSessionId && cached?.fingerprint) {
+  if (!options.forceNetwork && cached?.leadSessionId && cached?.fingerprint) {
     return cached;
   }
 
   identifyInProgress = true;
 
   try {
-    const fingerprint = await getBrowserFingerprint(envId);
-    const parentUrl = new URL(window.location.href);
+    const fingerprint = cached?.fingerprint
+      ? { id: cached.fingerprint }
+      : await getBrowserFingerprint(envId);
+    const parentUrl = new URL(options.sourceUrl ?? window.location.href);
 
     const response = await fetch(LEAD_IDENTIFY_API, {
       method: "POST",
@@ -84,15 +100,18 @@ export async function identifyLead(
 
     const jsonData = await response.json();
 
-    if (response.ok && jsonData.data?.data) {
-      const leadId = jsonData.data.data.leadId || null;
-      const leadSessionId = jsonData.data.data.sessionId || null;
+    if (response.ok) {
+      const responseData = jsonData.data?.data ?? jsonData.data;
+      if (!responseData) return null;
+
+      const leadId = responseData.leadId || null;
+      const leadSessionId = responseData.sessionId || null;
 
       setLeadDataWithTTL({
         leadId,
         leadSessionId,
         fingerprint: fingerprint.id,
-        landingPageUrl: window.location.href,
+        landingPageUrl: parentUrl.href,
       });
 
       return { leadId, leadSessionId, fingerprint: fingerprint.id };
@@ -119,4 +138,14 @@ async function waitForCachedData(): Promise<LeadData | null> {
     }
   }
   return null;
+}
+
+async function waitForIdentifyToFinish(): Promise<void> {
+  const maxWait = 5000;
+  const interval = 100;
+  const start = Date.now();
+
+  while (identifyInProgress && Date.now() - start < maxWait) {
+    await new Promise((r) => setTimeout(r, interval));
+  }
 }

--- a/src/lead/pageview.ts
+++ b/src/lead/pageview.ts
@@ -1,0 +1,62 @@
+import { onRouteChange } from "../utils/route-observer";
+import { getLeadDataWithTTL, identifyLead } from "./identify";
+import type { LeadData } from "../types";
+
+let routeListenersInstalled = false;
+let lastTrackedHref: string | null = null;
+let trackingQueue: Promise<unknown> = Promise.resolve();
+const pendingByHref: Partial<Record<string, Promise<LeadData | null>>> = {};
+
+export function initializePageviewTracking(envId: string | null): void {
+  if (!envId) return;
+
+  trackCurrentPage(envId);
+
+  if (routeListenersInstalled) return;
+  routeListenersInstalled = true;
+
+  onRouteChange(() => {
+    setTimeout(() => {
+      trackCurrentPage(envId);
+    }, 0);
+  });
+}
+
+export function trackCurrentPage(envId: string): Promise<LeadData | null> {
+  const href = window.location.href;
+
+  if (href === lastTrackedHref) {
+    return Promise.resolve(getLeadDataWithTTL());
+  }
+
+  if (pendingByHref[href]) {
+    return pendingByHref[href];
+  }
+
+  const request = trackingQueue
+    .catch(() => null)
+    .then(async () => {
+      if (href === lastTrackedHref) {
+        return getLeadDataWithTTL();
+      }
+
+      const data = await identifyLead(envId, {
+        forceNetwork: true,
+        sourceUrl: href,
+      });
+
+      if (data) {
+        lastTrackedHref = href;
+      }
+
+      return data;
+    })
+    .finally(() => {
+      delete pendingByHref[href];
+    });
+
+  pendingByHref[href] = request;
+  trackingQueue = request.then(() => null, () => null);
+
+  return request;
+}

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -111,18 +111,25 @@
       return null;
     }
   }
-  async function identifyLead(envId) {
+  async function identifyLead(envId, options = {}) {
+    if (identifyInProgress) {
+      if (options.forceNetwork) {
+        await waitForIdentifyToFinish();
+      } else {
+        return waitForCachedData();
+      }
+    }
     if (identifyInProgress) {
       return waitForCachedData();
     }
     const cached2 = getLeadDataWithTTL();
-    if (cached2?.leadSessionId && cached2?.fingerprint) {
+    if (!options.forceNetwork && cached2?.leadSessionId && cached2?.fingerprint) {
       return cached2;
     }
     identifyInProgress = true;
     try {
-      const fingerprint = await getBrowserFingerprint(envId);
-      const parentUrl = new URL(window.location.href);
+      const fingerprint = cached2?.fingerprint ? { id: cached2.fingerprint } : await getBrowserFingerprint(envId);
+      const parentUrl = new URL(options.sourceUrl ?? window.location.href);
       const response = await fetch(LEAD_IDENTIFY_API, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -139,14 +146,16 @@
         })
       });
       const jsonData = await response.json();
-      if (response.ok && jsonData.data?.data) {
-        const leadId = jsonData.data.data.leadId || null;
-        const leadSessionId = jsonData.data.data.sessionId || null;
+      if (response.ok) {
+        const responseData = jsonData.data?.data ?? jsonData.data;
+        if (!responseData) return null;
+        const leadId = responseData.leadId || null;
+        const leadSessionId = responseData.sessionId || null;
         setLeadDataWithTTL({
           leadId,
           leadSessionId,
           fingerprint: fingerprint.id,
-          landingPageUrl: window.location.href
+          landingPageUrl: parentUrl.href
         });
         return { leadId, leadSessionId, fingerprint: fingerprint.id };
       }
@@ -169,6 +178,90 @@
       }
     }
     return null;
+  }
+  async function waitForIdentifyToFinish() {
+    const maxWait = 5e3;
+    const interval = 100;
+    const start = Date.now();
+    while (identifyInProgress && Date.now() - start < maxWait) {
+      await new Promise((r) => setTimeout(r, interval));
+    }
+  }
+
+  // src/utils/route-observer.ts
+  var callbacks = [];
+  var installed = false;
+  var currentUrl = "";
+  function onRouteChange(callback) {
+    callbacks.push(callback);
+    if (!installed) {
+      install();
+      installed = true;
+    }
+  }
+  function notify() {
+    const newUrl = window.location.href;
+    if (newUrl === currentUrl) return;
+    currentUrl = newUrl;
+    callbacks.forEach((cb) => cb(newUrl));
+  }
+  function install() {
+    currentUrl = window.location.href;
+    window.addEventListener("popstate", notify);
+    const origPush = history.pushState;
+    const origReplace = history.replaceState;
+    history.pushState = function(...args) {
+      origPush.apply(history, args);
+      setTimeout(notify, 0);
+    };
+    history.replaceState = function(...args) {
+      origReplace.apply(history, args);
+      setTimeout(notify, 0);
+    };
+  }
+
+  // src/lead/pageview.ts
+  var routeListenersInstalled = false;
+  var lastTrackedHref = null;
+  var trackingQueue = Promise.resolve();
+  var pendingByHref = {};
+  function initializePageviewTracking(envId) {
+    if (!envId) return;
+    trackCurrentPage(envId);
+    if (routeListenersInstalled) return;
+    routeListenersInstalled = true;
+    onRouteChange(() => {
+      setTimeout(() => {
+        trackCurrentPage(envId);
+      }, 0);
+    });
+  }
+  function trackCurrentPage(envId) {
+    const href = window.location.href;
+    if (href === lastTrackedHref) {
+      return Promise.resolve(getLeadDataWithTTL());
+    }
+    if (pendingByHref[href]) {
+      return pendingByHref[href];
+    }
+    const request = trackingQueue.catch(() => null).then(async () => {
+      if (href === lastTrackedHref) {
+        return getLeadDataWithTTL();
+      }
+      const data = await identifyLead(envId, {
+        forceNetwork: true,
+        sourceUrl: href
+      });
+      if (data) {
+        lastTrackedHref = href;
+      }
+      return data;
+    }).finally(() => {
+      delete pendingByHref[href];
+    });
+    pendingByHref[href] = request;
+    trackingQueue = request.then(() => null, () => null);
+    return request;
   }
 
   // src/utils/debug.ts
@@ -242,38 +335,6 @@
       params[key] = value;
     }
     return params;
-  }
-
-  // src/utils/route-observer.ts
-  var callbacks = [];
-  var installed = false;
-  var currentUrl = "";
-  function onRouteChange(callback) {
-    callbacks.push(callback);
-    if (!installed) {
-      install();
-      installed = true;
-    }
-  }
-  function notify() {
-    const newUrl = window.location.href;
-    if (newUrl === currentUrl) return;
-    currentUrl = newUrl;
-    callbacks.forEach((cb) => cb(newUrl));
-  }
-  function install() {
-    currentUrl = window.location.href;
-    window.addEventListener("popstate", notify);
-    const origPush = history.pushState;
-    const origReplace = history.replaceState;
-    history.pushState = function(...args) {
-      origPush.apply(history, args);
-      setTimeout(notify, 0);
-    };
-    history.replaceState = function(...args) {
-      origReplace.apply(history, args);
-      setTimeout(notify, 0);
-    };
   }
 
   // src/store/message-listener.ts
@@ -1853,5 +1914,6 @@
     const scriptTag = document.currentScript;
     const environmentId2 = getSiteIdFromScript(scriptTag);
     setEnvironmentId(environmentId2);
+    initializePageviewTracking(environmentId2);
   })();
 })();

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -111,18 +111,25 @@
       return null;
     }
   }
-  async function identifyLead(envId) {
+  async function identifyLead(envId, options = {}) {
+    if (identifyInProgress) {
+      if (options.forceNetwork) {
+        await waitForIdentifyToFinish();
+      } else {
+        return waitForCachedData();
+      }
+    }
     if (identifyInProgress) {
       return waitForCachedData();
     }
     const cached2 = getLeadDataWithTTL();
-    if (cached2?.leadSessionId && cached2?.fingerprint) {
+    if (!options.forceNetwork && cached2?.leadSessionId && cached2?.fingerprint) {
       return cached2;
     }
     identifyInProgress = true;
     try {
-      const fingerprint = await getBrowserFingerprint(envId);
-      const parentUrl = new URL(window.location.href);
+      const fingerprint = cached2?.fingerprint ? { id: cached2.fingerprint } : await getBrowserFingerprint(envId);
+      const parentUrl = new URL(options.sourceUrl ?? window.location.href);
       const response = await fetch(LEAD_IDENTIFY_API, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -139,14 +146,16 @@
         })
       });
       const jsonData = await response.json();
-      if (response.ok && jsonData.data?.data) {
-        const leadId = jsonData.data.data.leadId || null;
-        const leadSessionId = jsonData.data.data.sessionId || null;
+      if (response.ok) {
+        const responseData = jsonData.data?.data ?? jsonData.data;
+        if (!responseData) return null;
+        const leadId = responseData.leadId || null;
+        const leadSessionId = responseData.sessionId || null;
         setLeadDataWithTTL({
           leadId,
           leadSessionId,
           fingerprint: fingerprint.id,
-          landingPageUrl: window.location.href
+          landingPageUrl: parentUrl.href
         });
         return { leadId, leadSessionId, fingerprint: fingerprint.id };
       }
@@ -169,6 +178,90 @@
       }
     }
     return null;
+  }
+  async function waitForIdentifyToFinish() {
+    const maxWait = 5e3;
+    const interval = 100;
+    const start = Date.now();
+    while (identifyInProgress && Date.now() - start < maxWait) {
+      await new Promise((r) => setTimeout(r, interval));
+    }
+  }
+
+  // src/utils/route-observer.ts
+  var callbacks = [];
+  var installed = false;
+  var currentUrl = "";
+  function onRouteChange(callback) {
+    callbacks.push(callback);
+    if (!installed) {
+      install();
+      installed = true;
+    }
+  }
+  function notify() {
+    const newUrl = window.location.href;
+    if (newUrl === currentUrl) return;
+    currentUrl = newUrl;
+    callbacks.forEach((cb) => cb(newUrl));
+  }
+  function install() {
+    currentUrl = window.location.href;
+    window.addEventListener("popstate", notify);
+    const origPush = history.pushState;
+    const origReplace = history.replaceState;
+    history.pushState = function(...args) {
+      origPush.apply(history, args);
+      setTimeout(notify, 0);
+    };
+    history.replaceState = function(...args) {
+      origReplace.apply(history, args);
+      setTimeout(notify, 0);
+    };
+  }
+
+  // src/lead/pageview.ts
+  var routeListenersInstalled = false;
+  var lastTrackedHref = null;
+  var trackingQueue = Promise.resolve();
+  var pendingByHref = {};
+  function initializePageviewTracking(envId) {
+    if (!envId) return;
+    trackCurrentPage(envId);
+    if (routeListenersInstalled) return;
+    routeListenersInstalled = true;
+    onRouteChange(() => {
+      setTimeout(() => {
+        trackCurrentPage(envId);
+      }, 0);
+    });
+  }
+  function trackCurrentPage(envId) {
+    const href = window.location.href;
+    if (href === lastTrackedHref) {
+      return Promise.resolve(getLeadDataWithTTL());
+    }
+    if (pendingByHref[href]) {
+      return pendingByHref[href];
+    }
+    const request = trackingQueue.catch(() => null).then(async () => {
+      if (href === lastTrackedHref) {
+        return getLeadDataWithTTL();
+      }
+      const data = await identifyLead(envId, {
+        forceNetwork: true,
+        sourceUrl: href
+      });
+      if (data) {
+        lastTrackedHref = href;
+      }
+      return data;
+    }).finally(() => {
+      delete pendingByHref[href];
+    });
+    pendingByHref[href] = request;
+    trackingQueue = request.then(() => null, () => null);
+    return request;
   }
 
   // src/utils/debug.ts
@@ -242,38 +335,6 @@
       params[key] = value;
     }
     return params;
-  }
-
-  // src/utils/route-observer.ts
-  var callbacks = [];
-  var installed = false;
-  var currentUrl = "";
-  function onRouteChange(callback) {
-    callbacks.push(callback);
-    if (!installed) {
-      install();
-      installed = true;
-    }
-  }
-  function notify() {
-    const newUrl = window.location.href;
-    if (newUrl === currentUrl) return;
-    currentUrl = newUrl;
-    callbacks.forEach((cb) => cb(newUrl));
-  }
-  function install() {
-    currentUrl = window.location.href;
-    window.addEventListener("popstate", notify);
-    const origPush = history.pushState;
-    const origReplace = history.replaceState;
-    history.pushState = function(...args) {
-      origPush.apply(history, args);
-      setTimeout(notify, 0);
-    };
-    history.replaceState = function(...args) {
-      origReplace.apply(history, args);
-      setTimeout(notify, 0);
-    };
   }
 
   // src/store/message-listener.ts
@@ -1853,5 +1914,6 @@
     const scriptTag = document.currentScript;
     const environmentId2 = getSiteIdFromScript(scriptTag);
     setEnvironmentId(environmentId2);
+    initializePageviewTracking(environmentId2);
   })();
 })();

--- a/test/content-analytics-pageviews.test.mjs
+++ b/test/content-analytics-pageviews.test.mjs
@@ -1,0 +1,304 @@
+import assert from "node:assert/strict";
+import { webcrypto } from "node:crypto";
+import test from "node:test";
+import vm from "node:vm";
+import { build } from "esbuild";
+
+const IDENTIFY_API = "https://forms.withsurface.com/api/v1/lead/identify";
+
+let bundledTag;
+let bundledPageviewTest;
+
+async function getBundledTag() {
+  if (bundledTag) return bundledTag;
+
+  const result = await build({
+    entryPoints: ["src/index.ts"],
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: "es2020",
+    write: false,
+  });
+
+  bundledTag = result.outputFiles[0].text;
+  return bundledTag;
+}
+
+async function getBundledPageviewTest() {
+  if (bundledPageviewTest) return bundledPageviewTest;
+
+  const result = await build({
+    stdin: {
+      contents: `
+        import { trackCurrentPage } from "./src/lead/pageview";
+        window.__trackCurrentPage = trackCurrentPage;
+      `,
+      resolveDir: process.cwd(),
+      sourcefile: "pageview-test-entry.ts",
+      loader: "ts",
+    },
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: "es2020",
+    write: false,
+  });
+
+  bundledPageviewTest = result.outputFiles[0].text;
+  return bundledPageviewTest;
+}
+
+function createHarness({ identifyResponses = [] } = {}) {
+  let href = "https://example.com/start?utm=one#top";
+  let cookie = "";
+  const listeners = {};
+  const fetchCalls = [];
+  const storage = new Map();
+
+  const setHref = (value) => {
+    const url = new URL(value, href);
+    href = url.href;
+    location.href = url.href;
+    location.hostname = url.hostname;
+    location.pathname = url.pathname;
+    location.search = url.search;
+    location.origin = url.origin;
+  };
+
+  const emit = (type, event = {}) => {
+    for (const callback of listeners[type] ?? []) {
+      callback(event);
+    }
+  };
+
+  const document = {
+    currentScript: {
+      getAttribute(name) {
+        return ["siteId", "siteid", "site-id", "data-site-id"].includes(name)
+          ? "env_test"
+          : null;
+      },
+    },
+    readyState: "complete",
+    referrer: "https://referrer.example/",
+    body: {},
+    documentElement: {},
+    addEventListener(type, callback) {
+      (listeners[type] ??= []).push(callback);
+    },
+    querySelectorAll() {
+      return [];
+    },
+    querySelector() {
+      return null;
+    },
+    createElement() {
+      return {};
+    },
+    get cookie() {
+      return cookie;
+    },
+    set cookie(value) {
+      const [pair] = value.split(";");
+      const [key, val] = pair.split("=");
+      const existing = cookie
+        .split(";")
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .filter((part) => !part.startsWith(`${key}=`));
+      if (!value.includes("max-age=0")) {
+        existing.push(`${key}=${val}`);
+      }
+      cookie = existing.join("; ");
+    },
+  };
+
+  const location = {};
+  setHref(href);
+
+  const history = {
+    pushState(_state, _title, url) {
+      if (url != null) setHref(url);
+    },
+    replaceState(_state, _title, url) {
+      if (url != null) setHref(url);
+    },
+  };
+
+  const context = {
+    Blob,
+    URL,
+    TextEncoder,
+    clearTimeout,
+    console,
+    crypto: webcrypto,
+    document,
+    history,
+    Intl,
+    location,
+    localStorage: {
+      getItem(key) {
+        return storage.get(key) ?? null;
+      },
+      setItem(key, value) {
+        storage.set(key, String(value));
+      },
+      removeItem(key) {
+        storage.delete(key);
+      },
+    },
+    navigator: {
+      language: "en-US",
+      plugins: [],
+      userAgent: "Surface Test Browser",
+    },
+    screen: {
+      width: 1440,
+      height: 900,
+      colorDepth: 24,
+    },
+    setTimeout,
+    window: null,
+    fetch: async (url, options = {}) => {
+      const body = options.body ? JSON.parse(options.body) : null;
+      fetchCalls.push({ url, body });
+
+      if (url === IDENTIFY_API) {
+        const next = identifyResponses.shift();
+        if (next instanceof Error) throw next;
+        if (next) return next;
+
+        return {
+          ok: true,
+          json: async () => ({
+            data: { data: { leadId: "lead_1", sessionId: "session_1" } },
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ data: { id: "journey_1" } }),
+      };
+    },
+    addEventListener(type, callback) {
+      (listeners[type] ??= []).push(callback);
+    },
+  };
+
+  context.window = context;
+  context.globalThis = context;
+
+  return {
+    context: vm.createContext(context),
+    fetchCalls,
+    get identifyCalls() {
+      return fetchCalls.filter((call) => call.url === IDENTIFY_API);
+    },
+    emit,
+    history,
+    setHref,
+    async runTag() {
+      const source = await getBundledTag();
+      vm.runInContext(source, this.context);
+      await waitFor(() => this.identifyCalls.length >= 1);
+    },
+  };
+}
+
+async function waitFor(predicate) {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > 1000) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+test("initial load calls identify once for the current page", async () => {
+  const harness = createHarness();
+
+  await harness.runTag();
+  await flush();
+
+  assert.equal(harness.identifyCalls.length, 1);
+  assert.deepEqual(harness.identifyCalls[0].body, {
+    fingerprint: harness.identifyCalls[0].body.fingerprint,
+    environmentId: "env_test",
+    source: "website",
+    sourceURL: "https://example.com/start?utm=one#top",
+    sourceURLDomain: "example.com",
+    sourceURLPath: "/start",
+    sourceUrlSearchParams: "?utm=one",
+  });
+  assert.equal("leadId" in harness.identifyCalls[0].body, false);
+  assert.equal("sessionIdFromParams" in harness.identifyCalls[0].body, false);
+});
+
+test("repeated same href does not call identify again", async () => {
+  const harness = createHarness();
+
+  await harness.runTag();
+  harness.history.pushState({}, "", "/start?utm=one#top");
+  await flush();
+
+  assert.equal(harness.identifyCalls.length, 1);
+});
+
+test("pushState, replaceState, and popstate identify changed URLs", async () => {
+  const harness = createHarness();
+
+  await harness.runTag();
+  harness.history.pushState({}, "", "/push");
+  await waitFor(() => harness.identifyCalls.length >= 2);
+
+  harness.history.replaceState({}, "", "/replace");
+  await waitFor(() => harness.identifyCalls.length >= 3);
+
+  harness.setHref("/back");
+  harness.emit("popstate");
+  await waitFor(() => harness.identifyCalls.length >= 4);
+
+  assert.equal(harness.identifyCalls[1].body.sourceURL, "https://example.com/push");
+  assert.equal(harness.identifyCalls[2].body.sourceURL, "https://example.com/replace");
+  assert.equal(harness.identifyCalls[3].body.sourceURL, "https://example.com/back");
+});
+
+test("subsequent identify payloads include stored lead and session identity", async () => {
+  const harness = createHarness();
+
+  await harness.runTag();
+  harness.history.pushState({}, "", "/next");
+  await waitFor(() => harness.identifyCalls.length >= 2);
+
+  assert.equal(harness.identifyCalls[1].body.leadId, "lead_1");
+  assert.equal(harness.identifyCalls[1].body.sessionIdFromParams, "session_1");
+});
+
+test("failed identify does not mark the URL as tracked", async () => {
+  const harness = createHarness({
+    identifyResponses: [
+      {
+        ok: false,
+        json: async () => ({ error: "failed" }),
+      },
+    ],
+  });
+
+  const source = await getBundledPageviewTest();
+  vm.runInContext(source, harness.context);
+  await harness.context.__trackCurrentPage("env_test");
+
+  assert.equal(harness.identifyCalls.length, 1);
+
+  await harness.context.__trackCurrentPage("env_test");
+
+  assert.equal(harness.identifyCalls.length, 2);
+  assert.equal(harness.identifyCalls[1].body.sourceURL, "https://example.com/start?utm=one#top");
+});


### PR DESCRIPTION
## Summary
Adds Content Analytics pageview tracking through the existing lead identify endpoint on initial tag load and SPA route changes. The tag now forces pageview identify calls for changed URLs while reusing stored lead/session identity, including the returned session id as `sessionIdFromParams` on later calls. It dedupes exact same-href calls, leaves failed identifies retryable, and updates the built tag artifacts.

## Validation
Ran `pnpm test`, `pnpm typecheck`, `pnpm build`, and `git diff --check origin/main...`.
