### PR TITLE
feat(content-analytics): include environment in track metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,12 @@ import { SurfaceStore } from "./store/store";
 import { SurfaceExternalForm } from "./external-form/external-form";
 import { SurfaceEmbed } from "./embed/embed";
 
+const scriptTag = document.currentScript as HTMLScriptElement;
+const environmentId = getSiteIdFromScript(scriptTag);
+setEnvironmentId(environmentId);
+
 // Create singleton store
-const SurfaceTagStore = new SurfaceStore();
+const SurfaceTagStore = new SurfaceStore(environmentId);
 
 // Expose public API on window (backwards compatible)
 const w = window as unknown as Record<string, unknown>;
@@ -21,10 +25,3 @@ w.SurfaceIdentifyLead = identifyLead;
 w.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
 w.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
 w.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
-
-// Auto-init: read site-id from the <script> tag
-(function () {
-  const scriptTag = document.currentScript as HTMLScriptElement;
-  const environmentId = getSiteIdFromScript(scriptTag);
-  setEnvironmentId(environmentId);
-})();

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -27,9 +27,10 @@ export class SurfaceStore {
   userJourneyId: string | null;
   userJourney: unknown[];
   cachedIdentifyData: LeadData | null;
+  environmentId: string | null;
   log: Logger;
 
-  constructor() {
+  constructor(environmentId: string | null = null) {
     this.windowUrl = new URL(window.location.href).toString();
     this.origin = new URL(window.location.href).origin.toString();
     this.referrer = document.referrer || "";
@@ -43,6 +44,7 @@ export class SurfaceStore {
     this.userJourneyId = null;
     this.userJourney = [];
     this.cachedIdentifyData = getLeadDataWithTTL();
+    this.environmentId = environmentId;
     this.log = createLogger("Surface Store");
 
     initializeMessageListener(this);
@@ -52,6 +54,7 @@ export class SurfaceStore {
       !this.isCurrentOriginSurfaceDomain()
     ) {
       initializeUserJourneyTracking(
+        this.environmentId,
         this.log,
         () => this.userJourneyId,
         (id) => { this.userJourneyId = id; }
@@ -70,6 +73,7 @@ export class SurfaceStore {
       this.windowUrl = new URL(newUrl).toString();
 
       updateUserJourneyOnRouteChange(
+        this.environmentId,
         newUrl,
         this.log,
         () => this.userJourneyId,

--- a/src/store/user-journey.ts
+++ b/src/store/user-journey.ts
@@ -14,6 +14,7 @@ import {
 import type { Logger, JourneyTrackEvent } from "../types";
 
 export function initializeUserJourneyTracking(
+  environmentId: string | null,
   log: Logger,
   getJourneyId: () => string | null,
   setJourneyId: (id: string | null) => void
@@ -43,7 +44,10 @@ export function initializeUserJourneyTracking(
             referrer: document.referrer || "",
           },
         },
-        metadata: { ...(surfaceLeadData ?? {}) },
+        metadata: {
+          ...(environmentId ? { environmentId } : {}),
+          ...(surfaceLeadData ?? {}),
+        },
       },
       log,
       getJourneyId,
@@ -115,6 +119,7 @@ export async function trackToRedis(
 }
 
 export function updateUserJourneyOnRouteChange(
+  environmentId: string | null,
   newUrl: string,
   log: Logger,
   getJourneyId: () => string | null,
@@ -140,7 +145,10 @@ export function updateUserJourneyOnRouteChange(
             timestamp: new Date().toISOString(),
           },
         },
-        metadata: { ...(surfaceLeadData ?? {}) },
+        metadata: {
+          ...(environmentId ? { environmentId } : {}),
+          ...(surfaceLeadData ?? {}),
+        },
       },
       log,
       getJourneyId,

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -48,7 +48,7 @@
   }
 
   // src/lead/fingerprint.ts
-  async function getBrowserFingerprint(environmentId2) {
+  async function getBrowserFingerprint(environmentId3) {
     const fingerprint = {};
     fingerprint.deviceType = /Mobi|Android/i.test(navigator.userAgent) ? "Mobile" : "Desktop";
     fingerprint.screen = {
@@ -65,7 +65,7 @@
       fingerprint.plugins = Array.from(navigator.plugins).map((p) => p.name);
     }
     fingerprint.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    fingerprint.environmentId = environmentId2;
+    fingerprint.environmentId = environmentId3;
     const fingerprintString = JSON.stringify(fingerprint);
     const id = await getHash(fingerprintString);
     return { ...fingerprint, id };
@@ -326,7 +326,7 @@
   }
 
   // src/store/user-journey.ts
-  function initializeUserJourneyTracking(log, getJourneyId, setJourneyId) {
+  function initializeUserJourneyTracking(environmentId3, log, getJourneyId, setJourneyId) {
     try {
       const existingId = getExistingJourneyId();
       setJourneyId(existingId);
@@ -348,7 +348,10 @@
               referrer: document.referrer || ""
             }
           },
-          metadata: { ...surfaceLeadData ?? {} }
+          metadata: {
+            ...environmentId3 ? { environmentId: environmentId3 } : {},
+            ...surfaceLeadData ?? {}
+          }
         },
         log,
         getJourneyId,
@@ -403,7 +406,7 @@
       return null;
     }
   }
-  function updateUserJourneyOnRouteChange(newUrl, log, getJourneyId, setJourneyId) {
+  function updateUserJourneyOnRouteChange(environmentId3, newUrl, log, getJourneyId, setJourneyId) {
     try {
       const currentUrl2 = newUrl || window.location.href;
       const recentVisit = getCookie(SURFACE_USER_JOURNEY_RECENT_VISIT_COOKIE_NAME);
@@ -421,7 +424,10 @@
               timestamp: (/* @__PURE__ */ new Date()).toISOString()
             }
           },
-          metadata: { ...surfaceLeadData ?? {} }
+          metadata: {
+            ...environmentId3 ? { environmentId: environmentId3 } : {},
+            ...surfaceLeadData ?? {}
+          }
         },
         log,
         getJourneyId,
@@ -447,7 +453,7 @@
 
   // src/store/store.ts
   var SurfaceStore = class {
-    constructor() {
+    constructor(environmentId3 = null) {
       this.windowUrl = new URL(window.location.href).toString();
       this.origin = new URL(window.location.href).origin.toString();
       this.referrer = document.referrer || "";
@@ -461,10 +467,12 @@
       this.userJourneyId = null;
       this.userJourney = [];
       this.cachedIdentifyData = getLeadDataWithTTL();
+      this.environmentId = environmentId3;
       this.log = createLogger("Surface Store");
       initializeMessageListener(this);
       if ((this.cachedIdentifyData || !isIdentifyInProgress()) && !this.isCurrentOriginSurfaceDomain()) {
         initializeUserJourneyTracking(
+          this.environmentId,
           this.log,
           () => this.userJourneyId,
           (id) => {
@@ -482,6 +490,7 @@
       onRouteChange((newUrl) => {
         this.windowUrl = new URL(newUrl).toString();
         updateUserJourneyOnRouteChange(
+          this.environmentId,
           newUrl,
           this.log,
           () => this.userJourneyId,
@@ -1840,7 +1849,10 @@
   });
 
   // src/index.ts
-  var SurfaceTagStore = new SurfaceStore();
+  var scriptTag = document.currentScript;
+  var environmentId2 = getSiteIdFromScript(scriptTag);
+  setEnvironmentId(environmentId2);
+  var SurfaceTagStore = new SurfaceStore(environmentId2);
   var w = window;
   w.SurfaceEmbed = SurfaceEmbed;
   w.SurfaceExternalForm = SurfaceExternalForm;
@@ -1849,9 +1861,4 @@
   w.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
   w.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
   w.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
-  (function() {
-    const scriptTag = document.currentScript;
-    const environmentId2 = getSiteIdFromScript(scriptTag);
-    setEnvironmentId(environmentId2);
-  })();
 })();

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -48,7 +48,7 @@
   }
 
   // src/lead/fingerprint.ts
-  async function getBrowserFingerprint(environmentId2) {
+  async function getBrowserFingerprint(environmentId3) {
     const fingerprint = {};
     fingerprint.deviceType = /Mobi|Android/i.test(navigator.userAgent) ? "Mobile" : "Desktop";
     fingerprint.screen = {
@@ -65,7 +65,7 @@
       fingerprint.plugins = Array.from(navigator.plugins).map((p) => p.name);
     }
     fingerprint.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    fingerprint.environmentId = environmentId2;
+    fingerprint.environmentId = environmentId3;
     const fingerprintString = JSON.stringify(fingerprint);
     const id = await getHash(fingerprintString);
     return { ...fingerprint, id };
@@ -326,7 +326,7 @@
   }
 
   // src/store/user-journey.ts
-  function initializeUserJourneyTracking(log, getJourneyId, setJourneyId) {
+  function initializeUserJourneyTracking(environmentId3, log, getJourneyId, setJourneyId) {
     try {
       const existingId = getExistingJourneyId();
       setJourneyId(existingId);
@@ -348,7 +348,10 @@
               referrer: document.referrer || ""
             }
           },
-          metadata: { ...surfaceLeadData ?? {} }
+          metadata: {
+            ...environmentId3 ? { environmentId: environmentId3 } : {},
+            ...surfaceLeadData ?? {}
+          }
         },
         log,
         getJourneyId,
@@ -403,7 +406,7 @@
       return null;
     }
   }
-  function updateUserJourneyOnRouteChange(newUrl, log, getJourneyId, setJourneyId) {
+  function updateUserJourneyOnRouteChange(environmentId3, newUrl, log, getJourneyId, setJourneyId) {
     try {
       const currentUrl2 = newUrl || window.location.href;
       const recentVisit = getCookie(SURFACE_USER_JOURNEY_RECENT_VISIT_COOKIE_NAME);
@@ -421,7 +424,10 @@
               timestamp: (/* @__PURE__ */ new Date()).toISOString()
             }
           },
-          metadata: { ...surfaceLeadData ?? {} }
+          metadata: {
+            ...environmentId3 ? { environmentId: environmentId3 } : {},
+            ...surfaceLeadData ?? {}
+          }
         },
         log,
         getJourneyId,
@@ -447,7 +453,7 @@
 
   // src/store/store.ts
   var SurfaceStore = class {
-    constructor() {
+    constructor(environmentId3 = null) {
       this.windowUrl = new URL(window.location.href).toString();
       this.origin = new URL(window.location.href).origin.toString();
       this.referrer = document.referrer || "";
@@ -461,10 +467,12 @@
       this.userJourneyId = null;
       this.userJourney = [];
       this.cachedIdentifyData = getLeadDataWithTTL();
+      this.environmentId = environmentId3;
       this.log = createLogger("Surface Store");
       initializeMessageListener(this);
       if ((this.cachedIdentifyData || !isIdentifyInProgress()) && !this.isCurrentOriginSurfaceDomain()) {
         initializeUserJourneyTracking(
+          this.environmentId,
           this.log,
           () => this.userJourneyId,
           (id) => {
@@ -482,6 +490,7 @@
       onRouteChange((newUrl) => {
         this.windowUrl = new URL(newUrl).toString();
         updateUserJourneyOnRouteChange(
+          this.environmentId,
           newUrl,
           this.log,
           () => this.userJourneyId,
@@ -1840,7 +1849,10 @@
   });
 
   // src/index.ts
-  var SurfaceTagStore = new SurfaceStore();
+  var scriptTag = document.currentScript;
+  var environmentId2 = getSiteIdFromScript(scriptTag);
+  setEnvironmentId(environmentId2);
+  var SurfaceTagStore = new SurfaceStore(environmentId2);
   var w = window;
   w.SurfaceEmbed = SurfaceEmbed;
   w.SurfaceExternalForm = SurfaceExternalForm;
@@ -1849,9 +1861,4 @@
   w.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
   w.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
   w.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
-  (function() {
-    const scriptTag = document.currentScript;
-    const environmentId2 = getSiteIdFromScript(scriptTag);
-    setEnvironmentId(environmentId2);
-  })();
 })();


### PR DESCRIPTION
## What changed

- Initializes the tag environment id before constructing `SurfaceStore`.
- Passes that environment id into the existing user journey tracking flow.
- Adds `environmentId` to the existing `/api/v1/lead/track` metadata payload for initial pageviews and route-change pageviews.
- Rebuilds `surface_tag.js` and `surface_embed_v1.js`.

## Why

The Surface Forms backend Content Analytics PR now reuses the existing `/lead/track` pageview path instead of adding extra identify calls. The track endpoint already receives initial pageviews and SPA route changes; it only needs the environment id to aggregate pageviews per environment.

## Scope

This intentionally does not add a new endpoint, a new pageview module, forced identify calls, or new route observers.

## Validation

- `pnpm install`
- `pnpm typecheck`
- `pnpm build`
