### PR TITLE
SURF-1081 feat(open-trigger): auto-open a form from a URL query-param (edge map)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
 import { SurfaceStore } from "./store/store";
 import { SurfaceExternalForm } from "./external-form/external-form";
 import { SurfaceEmbed } from "./embed/embed";
+import { resolveOpenTriggersOnLoad } from "./open-triggers/open-triggers";
 
 const scriptTag = document.currentScript as HTMLScriptElement;
 const environmentId = getSiteIdFromScript(scriptTag);
@@ -25,3 +26,7 @@ w.SurfaceIdentifyLead = identifyLead;
 w.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
 w.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
 w.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
+
+// Auto-open a form when the host URL carries a configured `?<slug>=true` param.
+// Fire-and-forget; only touches the network when params are present.
+void resolveOpenTriggersOnLoad(environmentId);

--- a/src/open-triggers/open-triggers.ts
+++ b/src/open-triggers/open-triggers.ts
@@ -1,0 +1,107 @@
+import { EXTERNAL_FORM_API } from "../constants";
+import { SurfaceEmbed } from "../embed/embed";
+import { OpenTriggerEntry, OpenTriggersMap, pickOpenTrigger } from "./resolve";
+
+const SESSION_PREFIX = "surface_open_triggers:";
+// Self-healing cache: re-fetch the map after this long so a slug retargeted/disabled
+// by an admin is picked up within the same browser session.
+const CACHE_TTL_MS = 5 * 60 * 1000;
+// Virtual trigger class — matches no element on the page; we open programmatically.
+const OPEN_TRIGGER_TARGET = "surface-open-trigger-virtual";
+
+interface CachedMap {
+  map: OpenTriggersMap;
+  ts: number;
+}
+
+interface OverridableWindow {
+  __SURFACE_OPEN_TRIGGERS_MAP?: OpenTriggersMap;
+  __SURFACE_OPEN_TRIGGERS_BASE?: string;
+}
+
+/**
+ * On page load, if the host URL carries query params, fetch the environment's
+ * open-trigger map (edge-cached, server-resolved) and open the form whose slug is
+ * present as `?<slug>=true`. Opens a form even if it isn't already embedded on the
+ * page. No params → zero network. Always fails safe (never breaks the host page).
+ */
+export async function resolveOpenTriggersOnLoad(environmentId: string | null): Promise<void> {
+  try {
+    if (!environmentId) return;
+    // Cheapest possible short-circuit: only fetch when there's something to match.
+    if (!window.location.search) return;
+
+    const map = await fetchOpenTriggersMap(environmentId);
+    const entry = pickOpenTrigger(window.location.search, map);
+    if (!entry) return;
+
+    openTriggerForm(entry);
+  } catch {
+    // Auto-open must never break the host page.
+  }
+}
+
+async function fetchOpenTriggersMap(environmentId: string): Promise<OpenTriggersMap | null> {
+  const w = window as unknown as OverridableWindow;
+
+  // Test/escape hatch: a directly-injected map bypasses the network entirely.
+  if (w.__SURFACE_OPEN_TRIGGERS_MAP) return w.__SURFACE_OPEN_TRIGGERS_MAP;
+
+  const sessionKey = SESSION_PREFIX + environmentId;
+  try {
+    const cached = sessionStorage.getItem(sessionKey);
+    if (cached) {
+      const parsed = JSON.parse(cached) as Partial<CachedMap>;
+      if (parsed && parsed.map && typeof parsed.ts === "number" && Date.now() - parsed.ts < CACHE_TTL_MS) {
+        return parsed.map;
+      }
+    }
+  } catch {
+    // sessionStorage unavailable / malformed (e.g. privacy mode) — fall through to a live fetch.
+  }
+
+  const base = w.__SURFACE_OPEN_TRIGGERS_BASE || EXTERNAL_FORM_API;
+  const response = await fetch(`${base}/environments/${encodeURIComponent(environmentId)}/open-triggers`);
+  if (!response.ok) return null;
+
+  const json = (await response.json()) as { data?: OpenTriggersMap };
+  const map = json?.data ?? {};
+
+  try {
+    sessionStorage.setItem(sessionKey, JSON.stringify({ map, ts: Date.now() } satisfies CachedMap));
+  } catch {
+    // Non-fatal — caching is best-effort.
+  }
+  return map;
+}
+
+function openTriggerForm(entry: OpenTriggerEntry): void {
+  // Match by URL pathname (e.g. "/s/<formId>"), not a substring of formId — so IDs
+  // that share a prefix can't collide, and preview/cache-bust query params on an
+  // existing embed's src don't affect the comparison.
+  let targetPathname: string | null = null;
+  try {
+    targetPathname = new URL(entry.formSrc).pathname;
+  } catch {
+    // Malformed formSrc — let `new SurfaceEmbed` below surface it (caught upstream).
+  }
+
+  // Reuse an existing popup/slideover embed of this form if one is already on the page.
+  const existing =
+    targetPathname !== null
+      ? SurfaceEmbed._instances.find(
+          (inst) =>
+            (inst.embed_type === "popup" || inst.embed_type === "slideover") &&
+            !!inst.src &&
+            inst.src.pathname === targetPathname
+        )
+      : undefined;
+  if (existing) {
+    existing.showSurfaceForm();
+    return;
+  }
+
+  // Otherwise create it on the fly and open immediately.
+  const embed = new SurfaceEmbed(entry.formSrc, entry.mode, OPEN_TRIGGER_TARGET);
+  embed.showSurfaceForm();
+}

--- a/src/open-triggers/resolve.ts
+++ b/src/open-triggers/resolve.ts
@@ -1,0 +1,36 @@
+// Pure, dependency-free resolution for the URL-param auto-open feature, so it can
+// be unit-tested in isolation (no DOM, no SurfaceEmbed, no fetch).
+
+export interface OpenTriggerEntry {
+  formId: string;
+  formSrc: string;
+  mode: "popup" | "slideover";
+}
+
+export type OpenTriggersMap = Record<string, OpenTriggerEntry>;
+
+const OPENABLE_MODES = ["popup", "slideover"];
+
+/**
+ * Given the host page's `search` string and the environment's slug→form map,
+ * returns the entry to open — the first param set to `true` whose key is a known
+ * slug — or null for a clean no-op (no matching param / unknown slug / bad entry).
+ */
+export function pickOpenTrigger(
+  search: string,
+  map: OpenTriggersMap | null | undefined
+): OpenTriggerEntry | null {
+  if (!map) return null;
+
+  const params = new URLSearchParams(search);
+  for (const [key, value] of params) {
+    if (value !== "true") continue;
+    const entry = map[key];
+    // Require formId too: an empty formId would later make a substring/identity match
+    // succeed against any embed, opening the wrong form instead of failing safe.
+    if (entry && entry.formId && entry.formSrc && OPENABLE_MODES.includes(entry.mode)) {
+      return entry;
+    }
+  }
+  return null;
+}

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -1848,6 +1848,78 @@
     formInputTriggerInitialize
   });
 
+  // src/open-triggers/resolve.ts
+  var OPENABLE_MODES = ["popup", "slideover"];
+  function pickOpenTrigger(search, map) {
+    if (!map) return null;
+    const params = new URLSearchParams(search);
+    for (const [key, value] of params) {
+      if (value !== "true") continue;
+      const entry = map[key];
+      if (entry && entry.formId && entry.formSrc && OPENABLE_MODES.includes(entry.mode)) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  // src/open-triggers/open-triggers.ts
+  var SESSION_PREFIX = "surface_open_triggers:";
+  var CACHE_TTL_MS = 5 * 60 * 1e3;
+  var OPEN_TRIGGER_TARGET = "surface-open-trigger-virtual";
+  async function resolveOpenTriggersOnLoad(environmentId3) {
+    try {
+      if (!environmentId3) return;
+      if (!window.location.search) return;
+      const map = await fetchOpenTriggersMap(environmentId3);
+      const entry = pickOpenTrigger(window.location.search, map);
+      if (!entry) return;
+      openTriggerForm(entry);
+    } catch {
+    }
+  }
+  async function fetchOpenTriggersMap(environmentId3) {
+    const w2 = window;
+    if (w2.__SURFACE_OPEN_TRIGGERS_MAP) return w2.__SURFACE_OPEN_TRIGGERS_MAP;
+    const sessionKey = SESSION_PREFIX + environmentId3;
+    try {
+      const cached2 = sessionStorage.getItem(sessionKey);
+      if (cached2) {
+        const parsed = JSON.parse(cached2);
+        if (parsed && parsed.map && typeof parsed.ts === "number" && Date.now() - parsed.ts < CACHE_TTL_MS) {
+          return parsed.map;
+        }
+      }
+    } catch {
+    }
+    const base = w2.__SURFACE_OPEN_TRIGGERS_BASE || EXTERNAL_FORM_API;
+    const response = await fetch(`${base}/environments/${encodeURIComponent(environmentId3)}/open-triggers`);
+    if (!response.ok) return null;
+    const json = await response.json();
+    const map = json?.data ?? {};
+    try {
+      sessionStorage.setItem(sessionKey, JSON.stringify({ map, ts: Date.now() }));
+    } catch {
+    }
+    return map;
+  }
+  function openTriggerForm(entry) {
+    let targetPathname = null;
+    try {
+      targetPathname = new URL(entry.formSrc).pathname;
+    } catch {
+    }
+    const existing = targetPathname !== null ? SurfaceEmbed._instances.find(
+      (inst) => (inst.embed_type === "popup" || inst.embed_type === "slideover") && !!inst.src && inst.src.pathname === targetPathname
+    ) : void 0;
+    if (existing) {
+      existing.showSurfaceForm();
+      return;
+    }
+    const embed = new SurfaceEmbed(entry.formSrc, entry.mode, OPEN_TRIGGER_TARGET);
+    embed.showSurfaceForm();
+  }
+
   // src/index.ts
   var scriptTag = document.currentScript;
   var environmentId2 = getSiteIdFromScript(scriptTag);
@@ -1861,4 +1933,5 @@
   w.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
   w.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
   w.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
+  void resolveOpenTriggersOnLoad(environmentId2);
 })();

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -1848,6 +1848,78 @@
     formInputTriggerInitialize
   });
 
+  // src/open-triggers/resolve.ts
+  var OPENABLE_MODES = ["popup", "slideover"];
+  function pickOpenTrigger(search, map) {
+    if (!map) return null;
+    const params = new URLSearchParams(search);
+    for (const [key, value] of params) {
+      if (value !== "true") continue;
+      const entry = map[key];
+      if (entry && entry.formId && entry.formSrc && OPENABLE_MODES.includes(entry.mode)) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  // src/open-triggers/open-triggers.ts
+  var SESSION_PREFIX = "surface_open_triggers:";
+  var CACHE_TTL_MS = 5 * 60 * 1e3;
+  var OPEN_TRIGGER_TARGET = "surface-open-trigger-virtual";
+  async function resolveOpenTriggersOnLoad(environmentId3) {
+    try {
+      if (!environmentId3) return;
+      if (!window.location.search) return;
+      const map = await fetchOpenTriggersMap(environmentId3);
+      const entry = pickOpenTrigger(window.location.search, map);
+      if (!entry) return;
+      openTriggerForm(entry);
+    } catch {
+    }
+  }
+  async function fetchOpenTriggersMap(environmentId3) {
+    const w2 = window;
+    if (w2.__SURFACE_OPEN_TRIGGERS_MAP) return w2.__SURFACE_OPEN_TRIGGERS_MAP;
+    const sessionKey = SESSION_PREFIX + environmentId3;
+    try {
+      const cached2 = sessionStorage.getItem(sessionKey);
+      if (cached2) {
+        const parsed = JSON.parse(cached2);
+        if (parsed && parsed.map && typeof parsed.ts === "number" && Date.now() - parsed.ts < CACHE_TTL_MS) {
+          return parsed.map;
+        }
+      }
+    } catch {
+    }
+    const base = w2.__SURFACE_OPEN_TRIGGERS_BASE || EXTERNAL_FORM_API;
+    const response = await fetch(`${base}/environments/${encodeURIComponent(environmentId3)}/open-triggers`);
+    if (!response.ok) return null;
+    const json = await response.json();
+    const map = json?.data ?? {};
+    try {
+      sessionStorage.setItem(sessionKey, JSON.stringify({ map, ts: Date.now() }));
+    } catch {
+    }
+    return map;
+  }
+  function openTriggerForm(entry) {
+    let targetPathname = null;
+    try {
+      targetPathname = new URL(entry.formSrc).pathname;
+    } catch {
+    }
+    const existing = targetPathname !== null ? SurfaceEmbed._instances.find(
+      (inst) => (inst.embed_type === "popup" || inst.embed_type === "slideover") && !!inst.src && inst.src.pathname === targetPathname
+    ) : void 0;
+    if (existing) {
+      existing.showSurfaceForm();
+      return;
+    }
+    const embed = new SurfaceEmbed(entry.formSrc, entry.mode, OPEN_TRIGGER_TARGET);
+    embed.showSurfaceForm();
+  }
+
   // src/index.ts
   var scriptTag = document.currentScript;
   var environmentId2 = getSiteIdFromScript(scriptTag);
@@ -1861,4 +1933,5 @@
   w.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
   w.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
   w.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
+  void resolveOpenTriggersOnLoad(environmentId2);
 })();


### PR DESCRIPTION
## What changed
On page load the Surface tag reads the host URL's query params and, **only if a param is present**, fetches this environment's edge-cached open-trigger map and opens the form whose slug appears as `?<slug>=true` — **creating the popup/slideover on the fly** when the form isn't already embedded on the page.

This is the tag-side half. The server side (slug settings, the `slug → form` map, and the `GET /api/v1/environments/<envId>/open-triggers` endpoint) is in the `surface_forms` PR.

### How it works
- `src/open-triggers/resolve.ts` — pure `pickOpenTrigger(search, map)`: first `?<slug>=true` whose key is a known slug → its entry (or null). Unit-tested.
- `src/open-triggers/open-triggers.ts` — `resolveOpenTriggersOnLoad(envId)`: short-circuits when there are no params (zero network), else fetches the map (cached in `sessionStorage`), and opens — reusing an existing popup/slideover embed of that form if present, otherwise `new SurfaceEmbed(formSrc, mode, …)` + `showSurfaceForm()`.
- Wired into `src/index.ts` bootstrap (fire-and-forget).
- Fails safe: any error is a clean no-op; never breaks the host page.

### Why (replaces the postMessage approach)
The earlier design rode the slug up the iframe→tag `SEND_DATA` handshake, which depended on a hidden form fully loading + hydrating + running a React effect before the tag could learn its slug — slow and racy (often only fired once the form was opened manually). This server-resolved map removes that dependency entirely and also opens forms that aren't pre-embedded.

## Files
- `src/open-triggers/{resolve,open-triggers}.ts` — resolver + orchestrator.
- `src/index.ts` — bootstrap hook.
- `surface_tag.js` / `surface_embed_v1.js` — rebuilt bundles.
- `test/open-triggers.test.js` — unit tests for the resolver (`pnpm test`).
- `test/mock/*` + `test/open-trigger.html` — local harness.

## Validation
- `pnpm typecheck` clean; `pnpm test` → **11/11**; `pnpm build` rebuilds the bundle (feature present).
- **Manual E2E:** verified in a real browser against a real local form — `?talk-to-expert=true` creates + opens the form on the fly (popup & slideover); no param / non-matching → nothing opens and **zero network calls** (instances: 0).
- Local harness `test/mock/open-trigger-local-real.html` injects the map (`window.__SURFACE_OPEN_TRIGGERS_MAP`) so the real tag path runs without the KV namespace provisioned.

## Notes
- The map fetch URL base is `EXTERNAL_FORM_API` (overridable in tests via `window.__SURFACE_OPEN_TRIGGERS_BASE`); `formSrc` comes from the server, so it points at the right deployment.
- Resolution runs on initial load; SPA route-change re-trigger is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)