### PR TITLE
fix(open-trigger): reuse same-mode embed exactly, else isolated overlay (honors configured mode)

### DIFF
--- a/src/open-triggers/open-trigger-overlay.ts
+++ b/src/open-triggers/open-trigger-overlay.ts
@@ -1,0 +1,116 @@
+import { getPopupDimensions } from "../embed/popup-dimensions";
+import { getPopupStyles } from "../embed/styles/popup";
+import { getSlideoverStyles } from "../embed/styles/slideover";
+
+// Self-contained auto-open overlay. It renders the form using the EXACT same styles
+// as the canonical popup/slideover embeds (getPopupStyles / getSlideoverStyles) — no
+// bespoke CSS here — but re-scoped to its own ids/classes so it never collides with,
+// restyles, or mutates an embed already on the page. It deliberately does NOT register
+// a SurfaceEmbed (the customer's embed + trigger stay untouched).
+
+type Mode = "popup" | "slideover";
+
+// The overlay's own DOM namespace. The canonical styles target #surface-popup /
+// .surface-popup-content / #surface-iframe / .close-btn(-container) /
+// .surface-loading-spinner; we rename those tokens so the same rules apply to our
+// elements and nothing else.
+const ID = "surface-open-trigger";
+const CONTENT = "surface-ot-content";
+const IFRAME = "surface-ot-iframe";
+const CLOSEBOX = "surface-ot-closebox";
+const CLOSE = "surface-ot-close";
+const SPINNER = "surface-ot-spinner";
+const STYLE_ID = "surface-ot-style";
+
+let overlayEl: HTMLDivElement | null = null;
+let prevBodyOverflow = "";
+
+export function openTriggerOverlay(formSrc: string, mode: Mode): void {
+  if (overlayEl && document.body.contains(overlayEl)) {
+    show(overlayEl, mode);
+    return;
+  }
+
+  injectStyles(mode);
+
+  const overlay = document.createElement("div");
+  overlay.id = ID;
+  overlay.style.display = "none";
+  // Same structure as the canonical popup/slideover HTML, with namespaced classes/ids.
+  overlay.innerHTML = `
+    <div class="${CONTENT}">
+      <div style="display:flex;justify-content:center;align-items:center;height:100%;position:absolute;top:0;left:0;width:100%;pointer-events:none;">
+        <div class="${SPINNER}"></div>
+      </div>
+      <iframe id="${IFRAME}" src="${formSrc}" frameborder="0" allowfullscreen style="opacity:0;"></iframe>
+      <div class="${CLOSEBOX}" style="display:none;"><span class="${CLOSE}">&times;</span></div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  overlayEl = overlay;
+
+  const iframe = overlay.querySelector<HTMLIFrameElement>("#" + IFRAME);
+  const spinner = overlay.querySelector<HTMLElement>("." + SPINNER);
+  const closeBox = overlay.querySelector<HTMLElement>("." + CLOSEBOX);
+  if (iframe) {
+    iframe.onload = () => {
+      iframe.style.opacity = "1";
+      if (spinner) spinner.style.display = "none";
+      if (closeBox) closeBox.style.display = "flex";
+    };
+  }
+
+  const close = () => hide(overlay);
+  overlay.querySelector("." + CLOSE)?.addEventListener("click", close);
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) close();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && overlay.classList.contains("active")) close();
+  });
+
+  show(overlay, mode);
+}
+
+function show(overlay: HTMLDivElement, mode: Mode): void {
+  // Capture/restore the page's own overflow rather than forcing "auto".
+  prevBodyOverflow = document.body.style.overflow;
+  overlay.style.display = mode === "popup" ? "flex" : "block";
+  document.body.style.overflow = "hidden";
+  setTimeout(() => {
+    overlay.classList.add("active");
+    overlay.querySelector<HTMLIFrameElement>("#" + IFRAME)?.focus();
+  }, 50);
+}
+
+function hide(overlay: HTMLDivElement): void {
+  overlay.classList.remove("active");
+  document.body.style.overflow = prevBodyOverflow;
+  setTimeout(() => {
+    overlay.style.display = "none";
+  }, 250);
+}
+
+function injectStyles(mode: Mode): void {
+  if (document.getElementById(STYLE_ID)) return;
+  const canonical = mode === "popup" ? getPopupStyles(getPopupDimensions("medium")) : getSlideoverStyles();
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = namespace(canonical);
+  document.head.appendChild(style);
+}
+
+/**
+ * Re-scope the canonical embed styles to the overlay's own selectors. Order matters:
+ * replace the more specific tokens before their substrings (…-content before -popup,
+ * close-btn-container before close-btn).
+ */
+function namespace(css: string): string {
+  return css
+    .replace(/surface-popup-content/g, CONTENT)
+    .replace(/surface-loading-spinner/g, SPINNER)
+    .replace(/close-btn-container/g, CLOSEBOX)
+    .replace(/close-btn/g, CLOSE)
+    .replace(/surface-iframe/g, IFRAME)
+    .replace(/surface-popup/g, ID);
+}

--- a/src/open-triggers/open-trigger-overlay.ts
+++ b/src/open-triggers/open-trigger-overlay.ts
@@ -73,8 +73,13 @@ export function openTriggerOverlay(formSrc: string, mode: Mode): void {
 }
 
 function show(overlay: HTMLDivElement, mode: Mode): void {
-  // Capture/restore the page's own overflow rather than forcing "auto".
-  prevBodyOverflow = document.body.style.overflow;
+  // Capture/restore the page's own overflow rather than forcing "auto". Only capture
+  // on a true hidden→shown transition: on a re-show (overlay already visible, overflow
+  // already "hidden") this would otherwise save "hidden" and the next hide() would
+  // restore "hidden", leaving the host page's scroll permanently locked.
+  if (overlay.style.display === "none") {
+    prevBodyOverflow = document.body.style.overflow;
+  }
   overlay.style.display = mode === "popup" ? "flex" : "block";
   document.body.style.overflow = "hidden";
   setTimeout(() => {

--- a/src/open-triggers/open-trigger-overlay.ts
+++ b/src/open-triggers/open-trigger-overlay.ts
@@ -36,7 +36,6 @@ export function openTriggerOverlay(formSrc: string, mode: Mode): void {
   const overlay = document.createElement("div");
   overlay.id = ID;
   overlay.style.display = "none";
-  // Same structure as the canonical popup/slideover HTML, with namespaced classes/ids.
   overlay.innerHTML = `
     <div class="${CONTENT}">
       <div style="display:flex;justify-content:center;align-items:center;height:100%;position:absolute;top:0;left:0;width:100%;pointer-events:none;">

--- a/src/open-triggers/open-triggers.ts
+++ b/src/open-triggers/open-triggers.ts
@@ -33,7 +33,6 @@ interface OverridableWindow {
 export async function resolveOpenTriggersOnLoad(environmentId: string | null): Promise<void> {
   try {
     if (!environmentId) return;
-    // Cheapest possible short-circuit: only fetch when there's something to match.
     if (!window.location.search) return;
 
     const map = await fetchOpenTriggersMap(environmentId);

--- a/src/open-triggers/open-triggers.ts
+++ b/src/open-triggers/open-triggers.ts
@@ -1,13 +1,18 @@
 import { EXTERNAL_FORM_API } from "../constants";
 import { SurfaceEmbed } from "../embed/embed";
+import { openTriggerOverlay } from "./open-trigger-overlay";
 import { OpenTriggerEntry, OpenTriggersMap, pickOpenTrigger } from "./resolve";
 
 const SESSION_PREFIX = "surface_open_triggers:";
 // Self-healing cache: re-fetch the map after this long so a slug retargeted/disabled
 // by an admin is picked up within the same browser session.
 const CACHE_TTL_MS = 5 * 60 * 1000;
-// Virtual trigger class — matches no element on the page; we open programmatically.
-const OPEN_TRIGGER_TARGET = "surface-open-trigger-virtual";
+// A same-form, same-mode embed may be created on window.load (after this runs, most
+// visibly on a refresh when the cached map resolves instantly). Poll briefly for it so
+// we can reuse it (pixel-identical to what the customer configured) before falling back
+// to rendering our own overlay.
+const REUSE_POLL_INTERVAL_MS = 150;
+const REUSE_POLL_MAX_TRIES = 12; // ~1.8s
 
 interface CachedMap {
   map: OpenTriggersMap;
@@ -76,32 +81,38 @@ async function fetchOpenTriggersMap(environmentId: string): Promise<OpenTriggers
 }
 
 function openTriggerForm(entry: OpenTriggerEntry): void {
-  // Match by URL pathname (e.g. "/s/<formId>"), not a substring of formId — so IDs
-  // that share a prefix can't collide, and preview/cache-bust query params on an
-  // existing embed's src don't affect the comparison.
+  // Match by URL pathname ("/s/<formId>"), resilient to host/preview/cache-bust params.
   let targetPathname: string | null = null;
   try {
     targetPathname = new URL(entry.formSrc).pathname;
   } catch {
-    // Malformed formSrc — let `new SurfaceEmbed` below surface it (caught upstream).
+    // Malformed formSrc — the overlay fallback (caught upstream) handles it.
   }
 
-  // Reuse an existing popup/slideover embed of this form if one is already on the page.
-  const existing =
-    targetPathname !== null
-      ? SurfaceEmbed._instances.find(
-          (inst) =>
-            (inst.embed_type === "popup" || inst.embed_type === "slideover") &&
-            !!inst.src &&
-            inst.src.pathname === targetPathname
-        )
-      : undefined;
-  if (existing) {
-    existing.showSurfaceForm();
-    return;
-  }
+  const findSameModeEmbed = (): SurfaceEmbed | undefined =>
+    targetPathname === null
+      ? undefined
+      : SurfaceEmbed._instances.find(
+          (inst) => inst.embed_type === entry.mode && !!inst.src && inst.src.pathname === targetPathname
+        );
 
-  // Otherwise create it on the fly and open immediately.
-  const embed = new SurfaceEmbed(entry.formSrc, entry.mode, OPEN_TRIGGER_TARGET);
-  embed.showSurfaceForm();
+  // If the page already embeds this form in the SAME mode as the open-trigger setting,
+  // reuse that embed — it is exactly what the customer configured (size, styles, …) and
+  // avoids loading a duplicate iframe. Otherwise (different mode, or not embedded at
+  // all) render our own overlay in the configured mode using the canonical styles.
+  let tries = 0;
+  const attempt = () => {
+    const sameMode = findSameModeEmbed();
+    if (sameMode) {
+      sameMode.showSurfaceForm();
+      return;
+    }
+    if (tries < REUSE_POLL_MAX_TRIES) {
+      tries += 1;
+      setTimeout(attempt, REUSE_POLL_INTERVAL_MS);
+      return;
+    }
+    openTriggerOverlay(entry.formSrc, entry.mode);
+  };
+  attempt();
 }

--- a/src/open-triggers/open-triggers.ts
+++ b/src/open-triggers/open-triggers.ts
@@ -89,12 +89,18 @@ function openTriggerForm(entry: OpenTriggerEntry): void {
     // Malformed formSrc — the overlay fallback (caught upstream) handles it.
   }
 
+  // No pathname to match against (malformed formSrc) → no embed can ever match, so
+  // skip the poll and render the overlay straight away (it surfaces its own load error
+  // if the src is truly bad), instead of waiting out the full reuse window for nothing.
+  if (targetPathname === null) {
+    openTriggerOverlay(entry.formSrc, entry.mode);
+    return;
+  }
+
   const findSameModeEmbed = (): SurfaceEmbed | undefined =>
-    targetPathname === null
-      ? undefined
-      : SurfaceEmbed._instances.find(
-          (inst) => inst.embed_type === entry.mode && !!inst.src && inst.src.pathname === targetPathname
-        );
+    SurfaceEmbed._instances.find(
+      (inst) => inst.embed_type === entry.mode && !!inst.src && inst.src.pathname === targetPathname
+    );
 
   // If the page already embeds this form in the SAME mode as the open-trigger setting,
   // reuse that embed — it is exactly what the customer configured (size, styles, …) and
@@ -102,17 +108,23 @@ function openTriggerForm(entry: OpenTriggerEntry): void {
   // all) render our own overlay in the configured mode using the canonical styles.
   let tries = 0;
   const attempt = () => {
-    const sameMode = findSameModeEmbed();
-    if (sameMode) {
-      sameMode.showSurfaceForm();
-      return;
+    // Delayed invocations run outside resolveOpenTriggersOnLoad's try/catch, so guard
+    // every attempt here — a throw must never escape to the host page's console.
+    try {
+      const sameMode = findSameModeEmbed();
+      if (sameMode) {
+        sameMode.showSurfaceForm();
+        return;
+      }
+      if (tries < REUSE_POLL_MAX_TRIES) {
+        tries += 1;
+        setTimeout(attempt, REUSE_POLL_INTERVAL_MS);
+        return;
+      }
+      openTriggerOverlay(entry.formSrc, entry.mode);
+    } catch {
+      // Auto-open must never break the host page.
     }
-    if (tries < REUSE_POLL_MAX_TRIES) {
-      tries += 1;
-      setTimeout(attempt, REUSE_POLL_INTERVAL_MS);
-      return;
-    }
-    openTriggerOverlay(entry.formSrc, entry.mode);
   };
   attempt();
 }

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -1899,7 +1899,9 @@
     show(overlay, mode);
   }
   function show(overlay, mode) {
-    prevBodyOverflow = document.body.style.overflow;
+    if (overlay.style.display === "none") {
+      prevBodyOverflow = document.body.style.overflow;
+    }
     overlay.style.display = mode === "popup" ? "flex" : "block";
     document.body.style.overflow = "hidden";
     setTimeout(() => {
@@ -1988,22 +1990,29 @@
       targetPathname = new URL(entry.formSrc).pathname;
     } catch {
     }
-    const findSameModeEmbed = () => targetPathname === null ? void 0 : SurfaceEmbed._instances.find(
+    if (targetPathname === null) {
+      openTriggerOverlay(entry.formSrc, entry.mode);
+      return;
+    }
+    const findSameModeEmbed = () => SurfaceEmbed._instances.find(
       (inst) => inst.embed_type === entry.mode && !!inst.src && inst.src.pathname === targetPathname
     );
     let tries = 0;
     const attempt = () => {
-      const sameMode = findSameModeEmbed();
-      if (sameMode) {
-        sameMode.showSurfaceForm();
-        return;
+      try {
+        const sameMode = findSameModeEmbed();
+        if (sameMode) {
+          sameMode.showSurfaceForm();
+          return;
+        }
+        if (tries < REUSE_POLL_MAX_TRIES) {
+          tries += 1;
+          setTimeout(attempt, REUSE_POLL_INTERVAL_MS);
+          return;
+        }
+        openTriggerOverlay(entry.formSrc, entry.mode);
+      } catch {
       }
-      if (tries < REUSE_POLL_MAX_TRIES) {
-        tries += 1;
-        setTimeout(attempt, REUSE_POLL_INTERVAL_MS);
-        return;
-      }
-      openTriggerOverlay(entry.formSrc, entry.mode);
     };
     attempt();
   }

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -1848,6 +1848,84 @@
     formInputTriggerInitialize
   });
 
+  // src/open-triggers/open-trigger-overlay.ts
+  var ID = "surface-open-trigger";
+  var CONTENT = "surface-ot-content";
+  var IFRAME = "surface-ot-iframe";
+  var CLOSEBOX = "surface-ot-closebox";
+  var CLOSE = "surface-ot-close";
+  var SPINNER = "surface-ot-spinner";
+  var STYLE_ID = "surface-ot-style";
+  var overlayEl = null;
+  var prevBodyOverflow = "";
+  function openTriggerOverlay(formSrc, mode) {
+    if (overlayEl && document.body.contains(overlayEl)) {
+      show(overlayEl, mode);
+      return;
+    }
+    injectStyles(mode);
+    const overlay = document.createElement("div");
+    overlay.id = ID;
+    overlay.style.display = "none";
+    overlay.innerHTML = `
+    <div class="${CONTENT}">
+      <div style="display:flex;justify-content:center;align-items:center;height:100%;position:absolute;top:0;left:0;width:100%;pointer-events:none;">
+        <div class="${SPINNER}"></div>
+      </div>
+      <iframe id="${IFRAME}" src="${formSrc}" frameborder="0" allowfullscreen style="opacity:0;"></iframe>
+      <div class="${CLOSEBOX}" style="display:none;"><span class="${CLOSE}">&times;</span></div>
+    </div>
+  `;
+    document.body.appendChild(overlay);
+    overlayEl = overlay;
+    const iframe = overlay.querySelector("#" + IFRAME);
+    const spinner = overlay.querySelector("." + SPINNER);
+    const closeBox = overlay.querySelector("." + CLOSEBOX);
+    if (iframe) {
+      iframe.onload = () => {
+        iframe.style.opacity = "1";
+        if (spinner) spinner.style.display = "none";
+        if (closeBox) closeBox.style.display = "flex";
+      };
+    }
+    const close = () => hide(overlay);
+    overlay.querySelector("." + CLOSE)?.addEventListener("click", close);
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) close();
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && overlay.classList.contains("active")) close();
+    });
+    show(overlay, mode);
+  }
+  function show(overlay, mode) {
+    prevBodyOverflow = document.body.style.overflow;
+    overlay.style.display = mode === "popup" ? "flex" : "block";
+    document.body.style.overflow = "hidden";
+    setTimeout(() => {
+      overlay.classList.add("active");
+      overlay.querySelector("#" + IFRAME)?.focus();
+    }, 50);
+  }
+  function hide(overlay) {
+    overlay.classList.remove("active");
+    document.body.style.overflow = prevBodyOverflow;
+    setTimeout(() => {
+      overlay.style.display = "none";
+    }, 250);
+  }
+  function injectStyles(mode) {
+    if (document.getElementById(STYLE_ID)) return;
+    const canonical = mode === "popup" ? getPopupStyles(getPopupDimensions("medium")) : getSlideoverStyles();
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = namespace(canonical);
+    document.head.appendChild(style);
+  }
+  function namespace(css) {
+    return css.replace(/surface-popup-content/g, CONTENT).replace(/surface-loading-spinner/g, SPINNER).replace(/close-btn-container/g, CLOSEBOX).replace(/close-btn/g, CLOSE).replace(/surface-iframe/g, IFRAME).replace(/surface-popup/g, ID);
+  }
+
   // src/open-triggers/resolve.ts
   var OPENABLE_MODES = ["popup", "slideover"];
   function pickOpenTrigger(search, map) {
@@ -1866,7 +1944,8 @@
   // src/open-triggers/open-triggers.ts
   var SESSION_PREFIX = "surface_open_triggers:";
   var CACHE_TTL_MS = 5 * 60 * 1e3;
-  var OPEN_TRIGGER_TARGET = "surface-open-trigger-virtual";
+  var REUSE_POLL_INTERVAL_MS = 150;
+  var REUSE_POLL_MAX_TRIES = 12;
   async function resolveOpenTriggersOnLoad(environmentId3) {
     try {
       if (!environmentId3) return;
@@ -1909,15 +1988,24 @@
       targetPathname = new URL(entry.formSrc).pathname;
     } catch {
     }
-    const existing = targetPathname !== null ? SurfaceEmbed._instances.find(
-      (inst) => (inst.embed_type === "popup" || inst.embed_type === "slideover") && !!inst.src && inst.src.pathname === targetPathname
-    ) : void 0;
-    if (existing) {
-      existing.showSurfaceForm();
-      return;
-    }
-    const embed = new SurfaceEmbed(entry.formSrc, entry.mode, OPEN_TRIGGER_TARGET);
-    embed.showSurfaceForm();
+    const findSameModeEmbed = () => targetPathname === null ? void 0 : SurfaceEmbed._instances.find(
+      (inst) => inst.embed_type === entry.mode && !!inst.src && inst.src.pathname === targetPathname
+    );
+    let tries = 0;
+    const attempt = () => {
+      const sameMode = findSameModeEmbed();
+      if (sameMode) {
+        sameMode.showSurfaceForm();
+        return;
+      }
+      if (tries < REUSE_POLL_MAX_TRIES) {
+        tries += 1;
+        setTimeout(attempt, REUSE_POLL_INTERVAL_MS);
+        return;
+      }
+      openTriggerOverlay(entry.formSrc, entry.mode);
+    };
+    attempt();
   }
 
   // src/index.ts

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -1899,7 +1899,9 @@
     show(overlay, mode);
   }
   function show(overlay, mode) {
-    prevBodyOverflow = document.body.style.overflow;
+    if (overlay.style.display === "none") {
+      prevBodyOverflow = document.body.style.overflow;
+    }
     overlay.style.display = mode === "popup" ? "flex" : "block";
     document.body.style.overflow = "hidden";
     setTimeout(() => {
@@ -1988,22 +1990,29 @@
       targetPathname = new URL(entry.formSrc).pathname;
     } catch {
     }
-    const findSameModeEmbed = () => targetPathname === null ? void 0 : SurfaceEmbed._instances.find(
+    if (targetPathname === null) {
+      openTriggerOverlay(entry.formSrc, entry.mode);
+      return;
+    }
+    const findSameModeEmbed = () => SurfaceEmbed._instances.find(
       (inst) => inst.embed_type === entry.mode && !!inst.src && inst.src.pathname === targetPathname
     );
     let tries = 0;
     const attempt = () => {
-      const sameMode = findSameModeEmbed();
-      if (sameMode) {
-        sameMode.showSurfaceForm();
-        return;
+      try {
+        const sameMode = findSameModeEmbed();
+        if (sameMode) {
+          sameMode.showSurfaceForm();
+          return;
+        }
+        if (tries < REUSE_POLL_MAX_TRIES) {
+          tries += 1;
+          setTimeout(attempt, REUSE_POLL_INTERVAL_MS);
+          return;
+        }
+        openTriggerOverlay(entry.formSrc, entry.mode);
+      } catch {
       }
-      if (tries < REUSE_POLL_MAX_TRIES) {
-        tries += 1;
-        setTimeout(attempt, REUSE_POLL_INTERVAL_MS);
-        return;
-      }
-      openTriggerOverlay(entry.formSrc, entry.mode);
     };
     attempt();
   }

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -1848,6 +1848,84 @@
     formInputTriggerInitialize
   });
 
+  // src/open-triggers/open-trigger-overlay.ts
+  var ID = "surface-open-trigger";
+  var CONTENT = "surface-ot-content";
+  var IFRAME = "surface-ot-iframe";
+  var CLOSEBOX = "surface-ot-closebox";
+  var CLOSE = "surface-ot-close";
+  var SPINNER = "surface-ot-spinner";
+  var STYLE_ID = "surface-ot-style";
+  var overlayEl = null;
+  var prevBodyOverflow = "";
+  function openTriggerOverlay(formSrc, mode) {
+    if (overlayEl && document.body.contains(overlayEl)) {
+      show(overlayEl, mode);
+      return;
+    }
+    injectStyles(mode);
+    const overlay = document.createElement("div");
+    overlay.id = ID;
+    overlay.style.display = "none";
+    overlay.innerHTML = `
+    <div class="${CONTENT}">
+      <div style="display:flex;justify-content:center;align-items:center;height:100%;position:absolute;top:0;left:0;width:100%;pointer-events:none;">
+        <div class="${SPINNER}"></div>
+      </div>
+      <iframe id="${IFRAME}" src="${formSrc}" frameborder="0" allowfullscreen style="opacity:0;"></iframe>
+      <div class="${CLOSEBOX}" style="display:none;"><span class="${CLOSE}">&times;</span></div>
+    </div>
+  `;
+    document.body.appendChild(overlay);
+    overlayEl = overlay;
+    const iframe = overlay.querySelector("#" + IFRAME);
+    const spinner = overlay.querySelector("." + SPINNER);
+    const closeBox = overlay.querySelector("." + CLOSEBOX);
+    if (iframe) {
+      iframe.onload = () => {
+        iframe.style.opacity = "1";
+        if (spinner) spinner.style.display = "none";
+        if (closeBox) closeBox.style.display = "flex";
+      };
+    }
+    const close = () => hide(overlay);
+    overlay.querySelector("." + CLOSE)?.addEventListener("click", close);
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) close();
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && overlay.classList.contains("active")) close();
+    });
+    show(overlay, mode);
+  }
+  function show(overlay, mode) {
+    prevBodyOverflow = document.body.style.overflow;
+    overlay.style.display = mode === "popup" ? "flex" : "block";
+    document.body.style.overflow = "hidden";
+    setTimeout(() => {
+      overlay.classList.add("active");
+      overlay.querySelector("#" + IFRAME)?.focus();
+    }, 50);
+  }
+  function hide(overlay) {
+    overlay.classList.remove("active");
+    document.body.style.overflow = prevBodyOverflow;
+    setTimeout(() => {
+      overlay.style.display = "none";
+    }, 250);
+  }
+  function injectStyles(mode) {
+    if (document.getElementById(STYLE_ID)) return;
+    const canonical = mode === "popup" ? getPopupStyles(getPopupDimensions("medium")) : getSlideoverStyles();
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = namespace(canonical);
+    document.head.appendChild(style);
+  }
+  function namespace(css) {
+    return css.replace(/surface-popup-content/g, CONTENT).replace(/surface-loading-spinner/g, SPINNER).replace(/close-btn-container/g, CLOSEBOX).replace(/close-btn/g, CLOSE).replace(/surface-iframe/g, IFRAME).replace(/surface-popup/g, ID);
+  }
+
   // src/open-triggers/resolve.ts
   var OPENABLE_MODES = ["popup", "slideover"];
   function pickOpenTrigger(search, map) {
@@ -1866,7 +1944,8 @@
   // src/open-triggers/open-triggers.ts
   var SESSION_PREFIX = "surface_open_triggers:";
   var CACHE_TTL_MS = 5 * 60 * 1e3;
-  var OPEN_TRIGGER_TARGET = "surface-open-trigger-virtual";
+  var REUSE_POLL_INTERVAL_MS = 150;
+  var REUSE_POLL_MAX_TRIES = 12;
   async function resolveOpenTriggersOnLoad(environmentId3) {
     try {
       if (!environmentId3) return;
@@ -1909,15 +1988,24 @@
       targetPathname = new URL(entry.formSrc).pathname;
     } catch {
     }
-    const existing = targetPathname !== null ? SurfaceEmbed._instances.find(
-      (inst) => (inst.embed_type === "popup" || inst.embed_type === "slideover") && !!inst.src && inst.src.pathname === targetPathname
-    ) : void 0;
-    if (existing) {
-      existing.showSurfaceForm();
-      return;
-    }
-    const embed = new SurfaceEmbed(entry.formSrc, entry.mode, OPEN_TRIGGER_TARGET);
-    embed.showSurfaceForm();
+    const findSameModeEmbed = () => targetPathname === null ? void 0 : SurfaceEmbed._instances.find(
+      (inst) => inst.embed_type === entry.mode && !!inst.src && inst.src.pathname === targetPathname
+    );
+    let tries = 0;
+    const attempt = () => {
+      const sameMode = findSameModeEmbed();
+      if (sameMode) {
+        sameMode.showSurfaceForm();
+        return;
+      }
+      if (tries < REUSE_POLL_MAX_TRIES) {
+        tries += 1;
+        setTimeout(attempt, REUSE_POLL_INTERVAL_MS);
+        return;
+      }
+      openTriggerOverlay(entry.formSrc, entry.mode);
+    };
+    attempt();
   }
 
   // src/index.ts


### PR DESCRIPTION
## Behavior
Resolving `?<slug>=true` now picks the rendering that best matches what the customer configured:

1. **Form already embedded in the SAME mode as the setting** → **reuse that embed.** It's exactly what the customer set up — popup size, styles, everything — and avoids loading a duplicate iframe. (A same-mode embed is often created on `window.load`, i.e. after this runs — most visibly on a refresh when the cached map resolves instantly — so we poll ~1.8s for it.)
2. **Different mode, or not embedded** → render a dedicated **overlay** in the configured mode, using the **exact canonical styles** (`getPopupStyles` / `getSlideoverStyles`, re-scoped to its own ids). The setting wins, the look matches a normal embed, and it can't collide with or mutate any existing embed.

This supersedes:
- the original "reuse any popup/slideover" (which inherited the *embed's* mode instead of honoring the setting), and
- the refresh-race duplicate that collided with the customer's embed on the shared `#surface-popup` / `#surface-iframe` ids.

## Why the overlay is safe next to an existing embed
`src/open-triggers/open-trigger-overlay.ts` renders `#surface-open-trigger` / `.surface-ot-content` / `#surface-ot-iframe` with the canonical CSS re-scoped to those selectors. It never registers a `SurfaceEmbed` or touches `_instances`, has no shared id/CSS, and captures/restores `body` overflow — so the customer's embed and trigger are completely unaffected.

## Verified (local harness, real form)
- **Same-mode popup embed, custom 500×700 size** → reused at exactly 500×700, **no overlay**, **single iframe**.
- **Slideover embed + popup setting** → isolated **popup overlay**; customer slideover untouched (1 instance, hidden, single `#surface-popup`); their own button still opens their slideover; ESC closes the overlay.
- **Overlay vs real popup embed computed styles**: identical (backdrop, radius 15px, transitions, z-index, content size all match).
- `pnpm typecheck` clean; `pnpm test` 12/12; bundles rebuilt (jsdelivr auto-minifies into `surface_tag.min.js`).

## Trade-off
Only the different-mode overlay loads a second iframe (possible double "view" count). Same-mode reuse and not-embedded both load a single iframe. The overlay defaults to popup size "medium" (the open-trigger has no size field); the same-mode reuse path uses the embed's exact size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)