### PR TITLE
SURF-1415 feat(store): first-touch UTM persistence in the Surface tag

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,3 +26,6 @@ export const VALID_EMBED_TYPES = [
 export const LEAD_DATA_TTL = 10 * 60 * 1000; // 10 minutes
 export const JOURNEY_COOKIE_MAX_AGE = 5184000; // 60 days
 export const RECENT_VISIT_COOKIE_MAX_AGE = 86400; // 1 day
+
+export const FIRST_TOUCH_COOKIE_NAME = "surface_first_touch";
+export const FIRST_TOUCH_COOKIE_MAX_AGE = 2592000; // 30 days

--- a/src/store/first-touch.ts
+++ b/src/store/first-touch.ts
@@ -34,6 +34,10 @@ const QUALIFYING_PARAMS = [
 ] as const;
 
 const MAX_VALUE_LENGTH = 256;
+// Browsers cap a cookie (name + encoded value + attributes) at ~4093 bytes;
+// stay well under so the write is never silently rejected.
+const MAX_ENCODED_COOKIE_BYTES = 3500;
+const FALLBACK_VALUE_LENGTH = 64;
 
 interface FirstTouchRecord {
   params: Record<string, string>;
@@ -80,11 +84,34 @@ export function captureFirstTouch(): void {
     at: new Date().toISOString(),
   };
 
-  setCookie(FIRST_TOUCH_COOKIE_NAME, JSON.stringify(record), {
+  let serialized = JSON.stringify(record);
+  if (encodeURIComponent(serialized).length > MAX_ENCODED_COOKIE_BYTES) {
+    // Degrade rather than let the browser reject the oversized cookie:
+    // attribution params matter more than the diagnostic url/referrer.
+    record.url = "";
+    record.referrer = "";
+    Object.keys(record.params).forEach((key) => {
+      record.params[key] = record.params[key].slice(0, FALLBACK_VALUE_LENGTH);
+    });
+    serialized = JSON.stringify(record);
+    if (encodeURIComponent(serialized).length > MAX_ENCODED_COOKIE_BYTES) return;
+  }
+
+  const options = {
     maxAge: FIRST_TOUCH_COOKIE_MAX_AGE,
-    sameSite: "lax",
+    sameSite: "lax" as const,
+  };
+
+  setCookie(FIRST_TOUCH_COOKIE_NAME, serialized, {
+    ...options,
     domain: getJourneyCookieDomain(),
   });
+
+  // Public-suffix hosts (e.g. *.github.io) and IP hosts reject a base-domain
+  // attribute outright; retry host-only so the cookie still lands.
+  if (!getCookie(FIRST_TOUCH_COOKIE_NAME)) {
+    setCookie(FIRST_TOUCH_COOKIE_NAME, serialized, options);
+  }
 }
 
 export function getFirstTouchParams(): Record<string, string> {

--- a/src/store/first-touch.ts
+++ b/src/store/first-touch.ts
@@ -1,0 +1,102 @@
+import {
+  FIRST_TOUCH_COOKIE_NAME,
+  FIRST_TOUCH_COOKIE_MAX_AGE,
+} from "../constants";
+import { getCookie, setCookie } from "../utils/cookies";
+import { getUrlParams } from "../utils/url";
+import { getJourneyCookieDomain } from "./journey-cookies";
+
+// Attribution params persisted from the landing URL.
+const ATTRIBUTION_PARAMS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "gclid",
+  "fbclid",
+  "li_fat_id",
+  "msclkid",
+  "ttclid",
+] as const;
+
+// A visit only counts as a first touch when it carries a source/medium or an
+// ad click-id. utm_content alone is commonly used to tag internal CTAs
+// (e.g. ?utm_content=home_homepage-hero) and must not claim the slot.
+const QUALIFYING_PARAMS = [
+  "utm_source",
+  "utm_medium",
+  "gclid",
+  "fbclid",
+  "li_fat_id",
+  "msclkid",
+  "ttclid",
+] as const;
+
+const MAX_VALUE_LENGTH = 256;
+
+interface FirstTouchRecord {
+  params: Record<string, string>;
+  url: string;
+  referrer: string;
+  at: string;
+}
+
+// Sites sometimes append utm-style params to internal links; a same-origin
+// referrer means this navigation is not a real inbound touch.
+function isInternalNavigation(): boolean {
+  if (!document.referrer) return false;
+
+  try {
+    return new URL(document.referrer).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Persist the landing page's attribution params in a first-party cookie so
+ * they survive navigation to whichever page hosts the form. Write-once: an
+ * existing unexpired record is never overwritten (strict first-touch,
+ * matching how HubSpot computes Original Source).
+ */
+export function captureFirstTouch(): void {
+  if (getCookie(FIRST_TOUCH_COOKIE_NAME)) return;
+  if (isInternalNavigation()) return;
+
+  const urlParams = getUrlParams();
+  if (!QUALIFYING_PARAMS.some((key) => urlParams[key])) return;
+
+  const params: Record<string, string> = {};
+  ATTRIBUTION_PARAMS.forEach((key) => {
+    const value = urlParams[key];
+    if (value) params[key] = value.slice(0, MAX_VALUE_LENGTH);
+  });
+
+  const record: FirstTouchRecord = {
+    params,
+    url: window.location.href.slice(0, MAX_VALUE_LENGTH),
+    referrer: document.referrer.slice(0, MAX_VALUE_LENGTH),
+    at: new Date().toISOString(),
+  };
+
+  setCookie(FIRST_TOUCH_COOKIE_NAME, JSON.stringify(record), {
+    maxAge: FIRST_TOUCH_COOKIE_MAX_AGE,
+    sameSite: "lax",
+    domain: getJourneyCookieDomain(),
+  });
+}
+
+export function getFirstTouchParams(): Record<string, string> {
+  const raw = getCookie(FIRST_TOUCH_COOKIE_NAME);
+  if (!raw) return {};
+
+  try {
+    const record = JSON.parse(raw) as FirstTouchRecord;
+    return record?.params && typeof record.params === "object"
+      ? record.params
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -6,6 +6,7 @@ import { getUrlParams } from "../utils/url";
 import { onRouteChange } from "../utils/route-observer";
 import { getLeadDataWithTTL, isIdentifyInProgress } from "../lead/identify";
 import { initializeMessageListener } from "./message-listener";
+import { captureFirstTouch, getFirstTouchParams } from "./first-touch";
 import {
   initializeUserJourneyTracking,
   updateUserJourneyOnRouteChange,
@@ -48,6 +49,10 @@ export class SurfaceStore {
     this.log = createLogger("Surface Store");
 
     initializeMessageListener(this);
+
+    if (!this.isCurrentOriginSurfaceDomain()) {
+      captureFirstTouch();
+    }
 
     if (
       (this.cachedIdentifyData || !isIdentifyInProgress()) &&
@@ -126,7 +131,8 @@ export class SurfaceStore {
           : this.cookies,
       origin: this.origin,
       questionIds: this.partialFilledData,
-      urlParams: this.urlParams,
+      // First-touch attribution fills gaps; current-page params always win.
+      urlParams: { ...getFirstTouchParams(), ...this.urlParams },
       surfaceLeadData: getLeadDataWithTTL(),
       userJourneyId: this.userJourneyId,
     };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -95,9 +95,6 @@ export class SurfaceStore {
     const iframes = document.querySelectorAll("iframe");
     if (iframes.length === 0) return;
 
-    this.urlParams = getUrlParams();
-    this.urlParams.url = window.location.href;
-
     this.log.info({ message: "Updating iframe params", response: { type, iframeCount: iframes.length } });
 
     iframes.forEach((iframe) => this.notifyIframe(iframe, type));
@@ -122,6 +119,12 @@ export class SurfaceStore {
   }
 
   getPayload(): StorePayload {
+    // Read params fresh: the direct notifyIframe() path can run before
+    // sendPayloadToIframes() ever refreshed this.urlParams, and after an SPA
+    // route change the cached value may belong to the previous page.
+    this.urlParams = getUrlParams();
+    this.urlParams.url = window.location.href;
+
     return {
       windowUrl: this.windowUrl,
       referrer: this.referrer,

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -37,6 +37,8 @@
   var LEAD_DATA_TTL = 10 * 60 * 1e3;
   var JOURNEY_COOKIE_MAX_AGE = 5184e3;
   var RECENT_VISIT_COOKIE_MAX_AGE = 86400;
+  var FIRST_TOUCH_COOKIE_NAME = "surface_first_touch";
+  var FIRST_TOUCH_COOKIE_MAX_AGE = 2592e3;
 
   // src/utils/hash.ts
   async function getHash(input) {
@@ -325,6 +327,70 @@
     return getCookie(SURFACE_USER_JOURNEY_COOKIE_NAME);
   }
 
+  // src/store/first-touch.ts
+  var ATTRIBUTION_PARAMS = [
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "gclid",
+    "fbclid",
+    "li_fat_id",
+    "msclkid",
+    "ttclid"
+  ];
+  var QUALIFYING_PARAMS = [
+    "utm_source",
+    "utm_medium",
+    "gclid",
+    "fbclid",
+    "li_fat_id",
+    "msclkid",
+    "ttclid"
+  ];
+  var MAX_VALUE_LENGTH = 256;
+  function isInternalNavigation() {
+    if (!document.referrer) return false;
+    try {
+      return new URL(document.referrer).origin === window.location.origin;
+    } catch {
+      return false;
+    }
+  }
+  function captureFirstTouch() {
+    if (getCookie(FIRST_TOUCH_COOKIE_NAME)) return;
+    if (isInternalNavigation()) return;
+    const urlParams = getUrlParams();
+    if (!QUALIFYING_PARAMS.some((key) => urlParams[key])) return;
+    const params = {};
+    ATTRIBUTION_PARAMS.forEach((key) => {
+      const value = urlParams[key];
+      if (value) params[key] = value.slice(0, MAX_VALUE_LENGTH);
+    });
+    const record = {
+      params,
+      url: window.location.href.slice(0, MAX_VALUE_LENGTH),
+      referrer: document.referrer.slice(0, MAX_VALUE_LENGTH),
+      at: (/* @__PURE__ */ new Date()).toISOString()
+    };
+    setCookie(FIRST_TOUCH_COOKIE_NAME, JSON.stringify(record), {
+      maxAge: FIRST_TOUCH_COOKIE_MAX_AGE,
+      sameSite: "lax",
+      domain: getJourneyCookieDomain()
+    });
+  }
+  function getFirstTouchParams() {
+    const raw = getCookie(FIRST_TOUCH_COOKIE_NAME);
+    if (!raw) return {};
+    try {
+      const record = JSON.parse(raw);
+      return record?.params && typeof record.params === "object" ? record.params : {};
+    } catch {
+      return {};
+    }
+  }
+
   // src/store/user-journey.ts
   function initializeUserJourneyTracking(environmentId3, log2, getJourneyId, setJourneyId) {
     try {
@@ -470,6 +536,9 @@
       this.environmentId = environmentId3;
       this.log = createLogger("Surface Store");
       initializeMessageListener(this);
+      if (!this.isCurrentOriginSurfaceDomain()) {
+        captureFirstTouch();
+      }
       if ((this.cachedIdentifyData || !isIdentifyInProgress()) && !this.isCurrentOriginSurfaceDomain()) {
         initializeUserJourneyTracking(
           this.environmentId,
@@ -532,7 +601,8 @@
         cookies: Object.keys(this.cookies).length === 0 ? parseCookies() : this.cookies,
         origin: this.origin,
         questionIds: this.partialFilledData,
-        urlParams: this.urlParams,
+        // First-touch attribution fills gaps; current-page params always win.
+        urlParams: { ...getFirstTouchParams(), ...this.urlParams },
         surfaceLeadData: getLeadDataWithTTL(),
         userJourneyId: this.userJourneyId
       };

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -350,6 +350,8 @@
     "ttclid"
   ];
   var MAX_VALUE_LENGTH = 256;
+  var MAX_ENCODED_COOKIE_BYTES = 3500;
+  var FALLBACK_VALUE_LENGTH = 64;
   function isInternalNavigation() {
     if (!document.referrer) return false;
     try {
@@ -374,11 +376,27 @@
       referrer: document.referrer.slice(0, MAX_VALUE_LENGTH),
       at: (/* @__PURE__ */ new Date()).toISOString()
     };
-    setCookie(FIRST_TOUCH_COOKIE_NAME, JSON.stringify(record), {
+    let serialized = JSON.stringify(record);
+    if (encodeURIComponent(serialized).length > MAX_ENCODED_COOKIE_BYTES) {
+      record.url = "";
+      record.referrer = "";
+      Object.keys(record.params).forEach((key) => {
+        record.params[key] = record.params[key].slice(0, FALLBACK_VALUE_LENGTH);
+      });
+      serialized = JSON.stringify(record);
+      if (encodeURIComponent(serialized).length > MAX_ENCODED_COOKIE_BYTES) return;
+    }
+    const options = {
       maxAge: FIRST_TOUCH_COOKIE_MAX_AGE,
-      sameSite: "lax",
+      sameSite: "lax"
+    };
+    setCookie(FIRST_TOUCH_COOKIE_NAME, serialized, {
+      ...options,
       domain: getJourneyCookieDomain()
     });
+    if (!getCookie(FIRST_TOUCH_COOKIE_NAME)) {
+      setCookie(FIRST_TOUCH_COOKIE_NAME, serialized, options);
+    }
   }
   function getFirstTouchParams() {
     const raw = getCookie(FIRST_TOUCH_COOKIE_NAME);
@@ -574,8 +592,6 @@
     sendPayloadToIframes(type) {
       const iframes = document.querySelectorAll("iframe");
       if (iframes.length === 0) return;
-      this.urlParams = getUrlParams();
-      this.urlParams.url = window.location.href;
       this.log.info({ message: "Updating iframe params", response: { type, iframeCount: iframes.length } });
       iframes.forEach((iframe) => this.notifyIframe(iframe, type));
     }
@@ -595,6 +611,8 @@
       return getUrlParams();
     }
     getPayload() {
+      this.urlParams = getUrlParams();
+      this.urlParams.url = window.location.href;
       return {
         windowUrl: this.windowUrl,
         referrer: this.referrer,

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -37,6 +37,8 @@
   var LEAD_DATA_TTL = 10 * 60 * 1e3;
   var JOURNEY_COOKIE_MAX_AGE = 5184e3;
   var RECENT_VISIT_COOKIE_MAX_AGE = 86400;
+  var FIRST_TOUCH_COOKIE_NAME = "surface_first_touch";
+  var FIRST_TOUCH_COOKIE_MAX_AGE = 2592e3;
 
   // src/utils/hash.ts
   async function getHash(input) {
@@ -325,6 +327,70 @@
     return getCookie(SURFACE_USER_JOURNEY_COOKIE_NAME);
   }
 
+  // src/store/first-touch.ts
+  var ATTRIBUTION_PARAMS = [
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "gclid",
+    "fbclid",
+    "li_fat_id",
+    "msclkid",
+    "ttclid"
+  ];
+  var QUALIFYING_PARAMS = [
+    "utm_source",
+    "utm_medium",
+    "gclid",
+    "fbclid",
+    "li_fat_id",
+    "msclkid",
+    "ttclid"
+  ];
+  var MAX_VALUE_LENGTH = 256;
+  function isInternalNavigation() {
+    if (!document.referrer) return false;
+    try {
+      return new URL(document.referrer).origin === window.location.origin;
+    } catch {
+      return false;
+    }
+  }
+  function captureFirstTouch() {
+    if (getCookie(FIRST_TOUCH_COOKIE_NAME)) return;
+    if (isInternalNavigation()) return;
+    const urlParams = getUrlParams();
+    if (!QUALIFYING_PARAMS.some((key) => urlParams[key])) return;
+    const params = {};
+    ATTRIBUTION_PARAMS.forEach((key) => {
+      const value = urlParams[key];
+      if (value) params[key] = value.slice(0, MAX_VALUE_LENGTH);
+    });
+    const record = {
+      params,
+      url: window.location.href.slice(0, MAX_VALUE_LENGTH),
+      referrer: document.referrer.slice(0, MAX_VALUE_LENGTH),
+      at: (/* @__PURE__ */ new Date()).toISOString()
+    };
+    setCookie(FIRST_TOUCH_COOKIE_NAME, JSON.stringify(record), {
+      maxAge: FIRST_TOUCH_COOKIE_MAX_AGE,
+      sameSite: "lax",
+      domain: getJourneyCookieDomain()
+    });
+  }
+  function getFirstTouchParams() {
+    const raw = getCookie(FIRST_TOUCH_COOKIE_NAME);
+    if (!raw) return {};
+    try {
+      const record = JSON.parse(raw);
+      return record?.params && typeof record.params === "object" ? record.params : {};
+    } catch {
+      return {};
+    }
+  }
+
   // src/store/user-journey.ts
   function initializeUserJourneyTracking(environmentId3, log2, getJourneyId, setJourneyId) {
     try {
@@ -470,6 +536,9 @@
       this.environmentId = environmentId3;
       this.log = createLogger("Surface Store");
       initializeMessageListener(this);
+      if (!this.isCurrentOriginSurfaceDomain()) {
+        captureFirstTouch();
+      }
       if ((this.cachedIdentifyData || !isIdentifyInProgress()) && !this.isCurrentOriginSurfaceDomain()) {
         initializeUserJourneyTracking(
           this.environmentId,
@@ -532,7 +601,8 @@
         cookies: Object.keys(this.cookies).length === 0 ? parseCookies() : this.cookies,
         origin: this.origin,
         questionIds: this.partialFilledData,
-        urlParams: this.urlParams,
+        // First-touch attribution fills gaps; current-page params always win.
+        urlParams: { ...getFirstTouchParams(), ...this.urlParams },
         surfaceLeadData: getLeadDataWithTTL(),
         userJourneyId: this.userJourneyId
       };

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -350,6 +350,8 @@
     "ttclid"
   ];
   var MAX_VALUE_LENGTH = 256;
+  var MAX_ENCODED_COOKIE_BYTES = 3500;
+  var FALLBACK_VALUE_LENGTH = 64;
   function isInternalNavigation() {
     if (!document.referrer) return false;
     try {
@@ -374,11 +376,27 @@
       referrer: document.referrer.slice(0, MAX_VALUE_LENGTH),
       at: (/* @__PURE__ */ new Date()).toISOString()
     };
-    setCookie(FIRST_TOUCH_COOKIE_NAME, JSON.stringify(record), {
+    let serialized = JSON.stringify(record);
+    if (encodeURIComponent(serialized).length > MAX_ENCODED_COOKIE_BYTES) {
+      record.url = "";
+      record.referrer = "";
+      Object.keys(record.params).forEach((key) => {
+        record.params[key] = record.params[key].slice(0, FALLBACK_VALUE_LENGTH);
+      });
+      serialized = JSON.stringify(record);
+      if (encodeURIComponent(serialized).length > MAX_ENCODED_COOKIE_BYTES) return;
+    }
+    const options = {
       maxAge: FIRST_TOUCH_COOKIE_MAX_AGE,
-      sameSite: "lax",
+      sameSite: "lax"
+    };
+    setCookie(FIRST_TOUCH_COOKIE_NAME, serialized, {
+      ...options,
       domain: getJourneyCookieDomain()
     });
+    if (!getCookie(FIRST_TOUCH_COOKIE_NAME)) {
+      setCookie(FIRST_TOUCH_COOKIE_NAME, serialized, options);
+    }
   }
   function getFirstTouchParams() {
     const raw = getCookie(FIRST_TOUCH_COOKIE_NAME);
@@ -574,8 +592,6 @@
     sendPayloadToIframes(type) {
       const iframes = document.querySelectorAll("iframe");
       if (iframes.length === 0) return;
-      this.urlParams = getUrlParams();
-      this.urlParams.url = window.location.href;
       this.log.info({ message: "Updating iframe params", response: { type, iframeCount: iframes.length } });
       iframes.forEach((iframe) => this.notifyIframe(iframe, type));
     }
@@ -595,6 +611,8 @@
       return getUrlParams();
     }
     getPayload() {
+      this.urlParams = getUrlParams();
+      this.urlParams.url = window.location.href;
       return {
         windowUrl: this.windowUrl,
         referrer: this.referrer,

--- a/test/first-touch.html
+++ b/test/first-touch.html
@@ -67,12 +67,6 @@
           : "(not set)";
 
         const store = window.SurfaceTagStore;
-        if (store) {
-          // Mirror sendPayloadToIframes(): refresh current-page params first,
-          // since this page hosts no iframe to trigger the real send path.
-          store.urlParams = store.getUrlParams();
-          store.urlParams.url = window.location.href;
-        }
         document.getElementById("payloadPanel").textContent = store
           ? JSON.stringify(store.getPayload().urlParams, null, 2)
           : "(SurfaceTagStore not initialized)";

--- a/test/first-touch.html
+++ b/test/first-touch.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>First-Touch UTM Persistence Test - Surface Tag</title>
+    <link rel="stylesheet" href="common.css">
+    <script src="../surface_tag.js" site-id="cllo318mt0003mb08hnp0f5zy"></script>
+  </head>
+  <body>
+    <div class="container">
+      <h1>First-Touch UTM Persistence Test</h1>
+      <p><a href="index.html">&larr; Back to Test Suite</a></p>
+
+      <div class="config-section">
+        <strong>How to test:</strong>
+        <ol>
+          <li><strong>Capture:</strong> paste this into the address bar (a real ad landing has no same-origin referrer; clicking a link here would trip the internal-navigation guard):<br><code>first-touch.html?utm_source=linkedin&amp;utm_medium=paid_social&amp;utm_campaign=Test+Campaign&amp;li_fat_id=test-123</code><br>The cookie panel should populate.</li>
+          <li><strong>Persistence:</strong> then <a href="first-touch.html?utm_content=home_homepage-hero">navigate with only an internal tag</a> — merged params should keep <code>utm_source=linkedin</code>, with <code>utm_content</code> from the current page winning.</li>
+          <li><strong>Internal-tag guard:</strong> clear the cookie, then click the internal-tag link above (same-origin referrer) — the cookie must NOT be written, even if the link carries <code>utm_source</code>.</li>
+          <li><strong>Write-once:</strong> with the cookie set, land again with <code>?utm_source=google&gclid=x</code> — the stored record must not change.</li>
+        </ol>
+      </div>
+
+      <h2>surface_first_touch cookie</h2>
+      <div class="button-group">
+        <button class="clear-log" onclick="clearFirstTouchCookie()">Clear Cookie</button>
+        <button class="secondary" onclick="render()">Refresh</button>
+      </div>
+      <pre class="events-log" id="cookiePanel"></pre>
+
+      <h2>Merged payload urlParams (what iframes receive)</h2>
+      <pre class="events-log" id="payloadPanel"></pre>
+    </div>
+
+    <script>
+      function getFirstTouchCookie() {
+        const match = document.cookie
+          .split(";")
+          .map((c) => c.trim())
+          .find((c) => c.startsWith("surface_first_touch="));
+        if (!match) return null;
+        try {
+          return JSON.parse(decodeURIComponent(match.split("=").slice(1).join("=")));
+        } catch {
+          return "<unparseable>";
+        }
+      }
+
+      function clearFirstTouchCookie() {
+        const hostname = window.location.hostname;
+        const parts = hostname.split(".");
+        const domain =
+          hostname.includes(".")
+            ? "." + (parts.length === 2 ? hostname : parts.slice(1).join("."))
+            : null;
+        document.cookie = "surface_first_touch=; path=/; max-age=0; samesite=lax" + (domain ? "; domain=" + domain : "");
+        document.cookie = "surface_first_touch=; path=/; max-age=0; samesite=lax";
+        render();
+      }
+
+      function render() {
+        const cookie = getFirstTouchCookie();
+        document.getElementById("cookiePanel").textContent = cookie
+          ? JSON.stringify(cookie, null, 2)
+          : "(not set)";
+
+        const store = window.SurfaceTagStore;
+        if (store) {
+          // Mirror sendPayloadToIframes(): refresh current-page params first,
+          // since this page hosts no iframe to trigger the real send path.
+          store.urlParams = store.getUrlParams();
+          store.urlParams.url = window.location.href;
+        }
+        document.getElementById("payloadPanel").textContent = store
+          ? JSON.stringify(store.getPayload().urlParams, null, 2)
+          : "(SurfaceTagStore not initialized)";
+      }
+
+      window.addEventListener("load", render);
+    </script>
+  </body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -44,6 +44,12 @@
           <p>Test input trigger that opens form with pre-filled email data.</p>
           <a href="input-trigger.html" class="nav-link">Test Input Trigger →</a>
         </div>
+
+        <div class="nav-card">
+          <h3>5. First-Touch UTM Persistence</h3>
+          <p>Test that landing-page attribution params persist across navigation and merge into STORE_UPDATE payloads.</p>
+          <a href="first-touch.html" class="nav-link">Test First Touch →</a>
+        </div>
       </div>
 
       <!-- Events Documentation -->


### PR DESCRIPTION
## Problem

Customers running paid campaigns lose attribution before a form is ever opened: the tag reads `window.location.search` fresh on every `STORE_UPDATE`, so a visitor who lands on a paid landing page with `utm_source`/`utm_medium`/click-id params and then navigates loses them — especially when internal CTAs replace the query string with internal tags (e.g. `?utm_content=home_homepage-hero`). Verified in Yuma's prod data: across two LinkedIn campaign windows, zero genuine prospect submissions carried LinkedIn-paid params. Paid Social shows zero in their HubSpot; contacts land as Direct/Offline.

Ticket: [SURF-1415](https://app.notion.com/p/39644c625b9f81deb1fbca4b2366d878)

## Change

- **`src/store/first-touch.ts` (new):** on page load, if the URL carries qualifying attribution params, persist `{ params, url, referrer, at }` in first-party cookie `surface_first_touch` (30-day max-age, base-domain scoped via `getJourneyCookieDomain()`, values capped at 256 chars).
  - Qualifying = `utm_source`, `utm_medium`, or a click-id (`gclid`, `fbclid`, `li_fat_id`, `msclkid`, `ttclid`). `utm_content` alone does **not** qualify — internal CTA tags would poison the slot.
  - Capture is skipped when `document.referrer` is same-origin (internal navigation), and is write-once until expiry (strict first-touch, matching HubSpot Original Source semantics).
  - Capture runs on page load only, not on SPA route changes — a route change with params is internal navigation by definition, and `document.referrer` is stale on pushState so the same-origin guard can't protect that path.
- **`SurfaceStore.getPayload()`:** merge `{ ...getFirstTouchParams(), ...this.urlParams }` — current-page params win, first-touch fills gaps. Merging here (not in `sendPayloadToIframes()`) also covers the direct `notifyIframe()` call on the embed partial-fill path.
- **`test/first-touch.html` (new):** manual test page showing the cookie and the merged payload params.

Downstream (form-render `URL_DATA.params` → HubSpot UTM hidden fields) is unchanged — the merged params flow through the existing plumbing.

## Verification (Playwright against the built bundle)

- Landing with `?utm_source=linkedin&utm_medium=paid_social&utm_campaign=Test+Campaign&li_fat_id=test-123&utm_content=ad-variant-a` → cookie written with all params.
- Navigating to `?utm_content=home_homepage-hero` → merged payload keeps all LinkedIn params, current page's `utm_content` wins.
- Same-origin navigation carrying `?utm_source=sneaky-internal` → cookie NOT written.
- `utm_content`-only landing with no referrer → cookie NOT written.
- Second external landing with `?utm_source=google&gclid=…` while cookie set → stored record unchanged (write-once); merged payload shows current-page google params winning, first-touch filling `utm_medium`.
- `pnpm run typecheck` + `pnpm run build` clean; `surface_tag.js`/`surface_embed_v1.js` rebuilt.

## Rollout note

Consumers load `@latest` from jsDelivr — purge `https://purge.jsdelivr.net/gh/trysurface/scripts@latest/surface_tag.min.js` after merge to make it land same-day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)