### PR TITLE
[SURF-1500] feat(conversions): fire ad-platform pixels from surface:conversion messages

### DIFF
--- a/src/conversions/conversion-listener.ts
+++ b/src/conversions/conversion-listener.ts
@@ -23,6 +23,7 @@ interface ConversionMessage {
   li_fat_id?: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isConversionMessage = (data: any): data is ConversionMessage =>
   !!data &&
   data.type === CONVERSION_MESSAGE_TYPE &&
@@ -39,8 +40,9 @@ export const handleConversionMessage = (event: MessageEvent, log: Logger): void 
   const data = event.data;
   if (!isConversionMessage(data)) return;
 
-  // Ack first — even if firing is blocked by an ad blocker, the iframe shouldn't
-  // double-fire in-frame. The pixel firing itself is best-effort.
+  // Ack unconditionally (after the best-effort fire below) — even when firing
+  // is blocked by an ad blocker, the iframe shouldn't double-fire in-frame.
+  // fireConversion swallows all errors, so the ack is always reached.
   const ack = () => {
     try {
       (event.source as WindowProxy | null)?.postMessage(

--- a/src/conversions/conversion-listener.ts
+++ b/src/conversions/conversion-listener.ts
@@ -1,0 +1,78 @@
+import type { Logger } from "../types";
+import { fireConversion, type ConversionProvider } from "./providers";
+
+// Wire contract with the iframe (surface_forms form-render). Keep in sync.
+const CONVERSION_MESSAGE_TYPE = "surface:conversion";
+const CONVERSION_ACK_TYPE = "surface:conversion:ack";
+
+const VALID_PROVIDERS: ConversionProvider[] = ["x", "meta", "ga4", "linkedin"];
+
+// Idempotency: a form may retry a send; only fire once per message id.
+const firedIds = new Set<string>();
+
+interface ConversionMessage {
+  type: typeof CONVERSION_MESSAGE_TYPE;
+  id: string;
+  provider: ConversionProvider;
+  event: Record<string, string>;
+  response_id: string;
+  email?: string;
+  twclid?: string;
+  fbclid?: string;
+  gclid?: string;
+  li_fat_id?: string;
+}
+
+const isConversionMessage = (data: any): data is ConversionMessage =>
+  !!data &&
+  data.type === CONVERSION_MESSAGE_TYPE &&
+  typeof data.id === "string" &&
+  VALID_PROVIDERS.includes(data.provider) &&
+  !!data.event &&
+  typeof data.response_id === "string";
+
+// Handles a `surface:conversion` message from a Surface form iframe: fires the
+// pixel in this (parent) page, then acks so the iframe knows not to fall back to
+// in-frame firing. The caller guarantees the origin is already trusted (checked
+// in the shared message listener against SURFACE_DOMAINS).
+export const handleConversionMessage = (event: MessageEvent, log: Logger): void => {
+  const data = event.data;
+  if (!isConversionMessage(data)) return;
+
+  // Ack first — even if firing is blocked by an ad blocker, the iframe shouldn't
+  // double-fire in-frame. The pixel firing itself is best-effort.
+  const ack = () => {
+    try {
+      (event.source as WindowProxy | null)?.postMessage(
+        { type: CONVERSION_ACK_TYPE, id: data.id },
+        event.origin
+      );
+    } catch {
+      /* no-op */
+    }
+  };
+
+  if (firedIds.has(data.id)) {
+    ack();
+    return;
+  }
+  firedIds.add(data.id);
+
+  const fired = fireConversion(data.provider, data.event, {
+    response_id: data.response_id,
+    email: data.email,
+    twclid: data.twclid,
+    fbclid: data.fbclid,
+    gclid: data.gclid,
+    li_fat_id: data.li_fat_id,
+  });
+
+  log.info({
+    message: "Conversion handled",
+    response: { provider: data.provider, responseId: data.response_id, fired },
+  });
+
+  ack();
+};
+
+export { CONVERSION_MESSAGE_TYPE };

--- a/src/conversions/providers.ts
+++ b/src/conversions/providers.ts
@@ -1,0 +1,131 @@
+// Ad-platform pixel firing in the parent page (first-party context). Mirrors the
+// in-frame firing in surface_forms (packages/form-render/.../fireConversion.ts) —
+// keep the two in sync. Each `ensure*` runs the vendor bootstrap only if the
+// global isn't already present, so we never double-inject over a pixel the
+// customer already runs.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type ConversionProvider = "x" | "meta" | "ga4" | "linkedin";
+
+export type ConversionEventPayload =
+  | { event_id: string; pixel_id: string } // x
+  | { pixel_id: string; event_name: string } // meta
+  | { measurement_id: string; event_name: string } // ga4
+  | { partner_id: string; conversion_id: string }; // linkedin
+
+export interface ConversionFireContext {
+  response_id: string;
+  email?: string;
+  twclid?: string;
+  fbclid?: string;
+  gclid?: string;
+  li_fat_id?: string;
+}
+
+const w = () => window as unknown as Record<string, any> & Window;
+
+const ensureTwq = (pixelId: string) => {
+  const win = w();
+  if (!win.twq) {
+    const s: any = (win.twq = function (...args: any[]) {
+      s.exe ? s.exe.apply(s, args) : s.queue.push(args);
+    });
+    s.version = "1.1";
+    s.queue = [];
+    const el = document.createElement("script");
+    el.async = true;
+    el.src = "https://static.ads-twitter.com/uwt.js";
+    document.head.appendChild(el);
+  }
+  win.twq("config", pixelId);
+};
+
+const ensureFbq = (pixelId: string) => {
+  const win = w();
+  if (!win.fbq) {
+    const n: any = (win.fbq = function (...args: any[]) {
+      n.callMethod ? n.callMethod.apply(n, args) : n.queue.push(args);
+    });
+    if (!win._fbq) win._fbq = n;
+    n.push = n;
+    n.loaded = true;
+    n.version = "2.0";
+    n.queue = [];
+    const el = document.createElement("script");
+    el.async = true;
+    el.src = "https://connect.facebook.net/en_US/fbevents.js";
+    document.head.appendChild(el);
+  }
+  win.fbq("init", pixelId);
+};
+
+const ensureGtag = (measurementId: string) => {
+  const win = w();
+  if (!win.gtag) {
+    win.dataLayer = win.dataLayer || [];
+    win.gtag = function (...args: any[]) {
+      win.dataLayer.push(args);
+    };
+    const el = document.createElement("script");
+    el.async = true;
+    el.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`;
+    document.head.appendChild(el);
+    win.gtag("js", new Date());
+    win.gtag("config", measurementId);
+  }
+};
+
+const ensureLintrk = (partnerId: string) => {
+  const win = w();
+  if (!win.lintrk) {
+    win._linkedin_partner_id = partnerId;
+    win._linkedin_data_partner_ids = win._linkedin_data_partner_ids || [];
+    win._linkedin_data_partner_ids.push(partnerId);
+    const l: any = (win.lintrk = function (a: any, b: any) {
+      l.q.push([a, b]);
+    });
+    l.q = [];
+    const el = document.createElement("script");
+    el.async = true;
+    el.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+    document.head.appendChild(el);
+  }
+};
+
+// Fire one conversion. Best-effort: returns false on any vendor/ad-block error.
+export const fireConversion = (
+  provider: ConversionProvider,
+  event: any,
+  ctx: ConversionFireContext
+): boolean => {
+  const win = w();
+  try {
+    switch (provider) {
+      case "x":
+        ensureTwq(event.pixel_id);
+        win.twq("event", event.event_id, {
+          conversion_id: ctx.response_id,
+          ...(ctx.twclid ? { twclid: ctx.twclid } : {}),
+          ...(ctx.email ? { email_address: ctx.email } : {}),
+        });
+        return true;
+      case "meta":
+        ensureFbq(event.pixel_id);
+        win.fbq("track", event.event_name, {}, { eventID: ctx.response_id });
+        return true;
+      case "ga4":
+        ensureGtag(event.measurement_id);
+        win.gtag("event", event.event_name, { transaction_id: ctx.response_id });
+        return true;
+      case "linkedin":
+        ensureLintrk(event.partner_id);
+        win.lintrk("track", { conversion_id: event.conversion_id });
+        return true;
+      default:
+        return false;
+    }
+  } catch {
+    return false;
+  }
+};

--- a/src/conversions/providers.ts
+++ b/src/conversions/providers.ts
@@ -72,16 +72,17 @@ const ensureGtag = (measurementId: string) => {
     el.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`;
     document.head.appendChild(el);
     win.gtag("js", new Date());
-    win.gtag("config", measurementId);
   }
+  // Register our measurement ID even when the page already runs gtag — without
+  // this the event routes only to the page's own GA4 properties. Idempotent;
+  // send_page_view off so registering never counts a phantom page view.
+  win.gtag("config", measurementId, { send_page_view: false });
 };
 
 const ensureLintrk = (partnerId: string) => {
   const win = w();
   if (!win.lintrk) {
     win._linkedin_partner_id = partnerId;
-    win._linkedin_data_partner_ids = win._linkedin_data_partner_ids || [];
-    win._linkedin_data_partner_ids.push(partnerId);
     const l: any = (win.lintrk = function (a: any, b: any) {
       l.q.push([a, b]);
     });
@@ -90,6 +91,13 @@ const ensureLintrk = (partnerId: string) => {
     el.async = true;
     el.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
     document.head.appendChild(el);
+  }
+  // Register the partner even when the customer's Insight Tag already runs —
+  // the tag reads _linkedin_data_partner_ids dynamically and supports multiple
+  // partners; without this the track call goes to the page's own partner only.
+  win._linkedin_data_partner_ids = win._linkedin_data_partner_ids || [];
+  if (!win._linkedin_data_partner_ids.includes(partnerId)) {
+    win._linkedin_data_partner_ids.push(partnerId);
   }
 };
 
@@ -116,7 +124,12 @@ export const fireConversion = (
         return true;
       case "ga4":
         ensureGtag(event.measurement_id);
-        win.gtag("event", event.event_name, { transaction_id: ctx.response_id });
+        // send_to pins the event to our property when the page's gtag also has
+        // its own measurement IDs configured.
+        win.gtag("event", event.event_name, {
+          transaction_id: ctx.response_id,
+          send_to: event.measurement_id,
+        });
         return true;
       case "linkedin":
         ensureLintrk(event.partner_id);

--- a/src/store/message-listener.ts
+++ b/src/store/message-listener.ts
@@ -1,10 +1,16 @@
 import { SURFACE_DOMAINS } from "../constants";
+import { handleConversionMessage } from "../conversions/conversion-listener";
 import { identifyLead, getEnvironmentId } from "../lead/identify";
 import type { SurfaceStore } from "./store";
 
 export function initializeMessageListener(store: SurfaceStore): void {
   const handleMessage = (event: MessageEvent) => {
     if (!event.origin || !(SURFACE_DOMAINS as readonly string[]).includes(event.origin)) {
+      return;
+    }
+
+    if (event.data?.type === "surface:conversion") {
+      handleConversionMessage(event, store.log);
       return;
     }
 

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -276,10 +276,150 @@
     };
   }
 
+  // src/conversions/providers.ts
+  var w = () => window;
+  var ensureTwq = (pixelId) => {
+    const win = w();
+    if (!win.twq) {
+      const s = win.twq = function(...args) {
+        s.exe ? s.exe.apply(s, args) : s.queue.push(args);
+      };
+      s.version = "1.1";
+      s.queue = [];
+      const el = document.createElement("script");
+      el.async = true;
+      el.src = "https://static.ads-twitter.com/uwt.js";
+      document.head.appendChild(el);
+    }
+    win.twq("config", pixelId);
+  };
+  var ensureFbq = (pixelId) => {
+    const win = w();
+    if (!win.fbq) {
+      const n = win.fbq = function(...args) {
+        n.callMethod ? n.callMethod.apply(n, args) : n.queue.push(args);
+      };
+      if (!win._fbq) win._fbq = n;
+      n.push = n;
+      n.loaded = true;
+      n.version = "2.0";
+      n.queue = [];
+      const el = document.createElement("script");
+      el.async = true;
+      el.src = "https://connect.facebook.net/en_US/fbevents.js";
+      document.head.appendChild(el);
+    }
+    win.fbq("init", pixelId);
+  };
+  var ensureGtag = (measurementId) => {
+    const win = w();
+    if (!win.gtag) {
+      win.dataLayer = win.dataLayer || [];
+      win.gtag = function(...args) {
+        win.dataLayer.push(args);
+      };
+      const el = document.createElement("script");
+      el.async = true;
+      el.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`;
+      document.head.appendChild(el);
+      win.gtag("js", /* @__PURE__ */ new Date());
+      win.gtag("config", measurementId);
+    }
+  };
+  var ensureLintrk = (partnerId) => {
+    const win = w();
+    if (!win.lintrk) {
+      win._linkedin_partner_id = partnerId;
+      win._linkedin_data_partner_ids = win._linkedin_data_partner_ids || [];
+      win._linkedin_data_partner_ids.push(partnerId);
+      const l = win.lintrk = function(a, b) {
+        l.q.push([a, b]);
+      };
+      l.q = [];
+      const el = document.createElement("script");
+      el.async = true;
+      el.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+      document.head.appendChild(el);
+    }
+  };
+  var fireConversion = (provider, event, ctx) => {
+    const win = w();
+    try {
+      switch (provider) {
+        case "x":
+          ensureTwq(event.pixel_id);
+          win.twq("event", event.event_id, {
+            conversion_id: ctx.response_id,
+            ...ctx.twclid ? { twclid: ctx.twclid } : {},
+            ...ctx.email ? { email_address: ctx.email } : {}
+          });
+          return true;
+        case "meta":
+          ensureFbq(event.pixel_id);
+          win.fbq("track", event.event_name, {}, { eventID: ctx.response_id });
+          return true;
+        case "ga4":
+          ensureGtag(event.measurement_id);
+          win.gtag("event", event.event_name, { transaction_id: ctx.response_id });
+          return true;
+        case "linkedin":
+          ensureLintrk(event.partner_id);
+          win.lintrk("track", { conversion_id: event.conversion_id });
+          return true;
+        default:
+          return false;
+      }
+    } catch {
+      return false;
+    }
+  };
+
+  // src/conversions/conversion-listener.ts
+  var CONVERSION_MESSAGE_TYPE = "surface:conversion";
+  var CONVERSION_ACK_TYPE = "surface:conversion:ack";
+  var VALID_PROVIDERS = ["x", "meta", "ga4", "linkedin"];
+  var firedIds = /* @__PURE__ */ new Set();
+  var isConversionMessage = (data) => !!data && data.type === CONVERSION_MESSAGE_TYPE && typeof data.id === "string" && VALID_PROVIDERS.includes(data.provider) && !!data.event && typeof data.response_id === "string";
+  var handleConversionMessage = (event, log2) => {
+    const data = event.data;
+    if (!isConversionMessage(data)) return;
+    const ack = () => {
+      try {
+        event.source?.postMessage(
+          { type: CONVERSION_ACK_TYPE, id: data.id },
+          event.origin
+        );
+      } catch {
+      }
+    };
+    if (firedIds.has(data.id)) {
+      ack();
+      return;
+    }
+    firedIds.add(data.id);
+    const fired = fireConversion(data.provider, data.event, {
+      response_id: data.response_id,
+      email: data.email,
+      twclid: data.twclid,
+      fbclid: data.fbclid,
+      gclid: data.gclid,
+      li_fat_id: data.li_fat_id
+    });
+    log2.info({
+      message: "Conversion handled",
+      response: { provider: data.provider, responseId: data.response_id, fired }
+    });
+    ack();
+  };
+
   // src/store/message-listener.ts
   function initializeMessageListener(store) {
     const handleMessage = (event) => {
       if (!event.origin || !SURFACE_DOMAINS.includes(event.origin)) {
+        return;
+      }
+      if (event.data?.type === "surface:conversion") {
+        handleConversionMessage(event, store.log);
         return;
       }
       if (event.data.type === "SEND_DATA") {
@@ -1960,8 +2100,8 @@
     }
   }
   async function fetchOpenTriggersMap(environmentId3) {
-    const w2 = window;
-    if (w2.__SURFACE_OPEN_TRIGGERS_MAP) return w2.__SURFACE_OPEN_TRIGGERS_MAP;
+    const w3 = window;
+    if (w3.__SURFACE_OPEN_TRIGGERS_MAP) return w3.__SURFACE_OPEN_TRIGGERS_MAP;
     const sessionKey = SESSION_PREFIX + environmentId3;
     try {
       const cached2 = sessionStorage.getItem(sessionKey);
@@ -1973,7 +2113,7 @@
       }
     } catch {
     }
-    const base = w2.__SURFACE_OPEN_TRIGGERS_BASE || EXTERNAL_FORM_API;
+    const base = w3.__SURFACE_OPEN_TRIGGERS_BASE || EXTERNAL_FORM_API;
     const response = await fetch(`${base}/environments/${encodeURIComponent(environmentId3)}/open-triggers`);
     if (!response.ok) return null;
     const json = await response.json();
@@ -2220,14 +2360,14 @@
   var environmentId2 = getSiteIdFromScript(scriptTag);
   setEnvironmentId(environmentId2);
   var SurfaceTagStore = new SurfaceStore(environmentId2);
-  var w = window;
-  w.SurfaceEmbed = SurfaceEmbed;
-  w.SurfaceExternalForm = SurfaceExternalForm;
-  w.SurfaceTagStore = SurfaceTagStore;
-  w.SurfaceIdentifyLead = identifyLead;
-  w.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
-  w.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
-  w.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
+  var w2 = window;
+  w2.SurfaceEmbed = SurfaceEmbed;
+  w2.SurfaceExternalForm = SurfaceExternalForm;
+  w2.SurfaceTagStore = SurfaceTagStore;
+  w2.SurfaceIdentifyLead = identifyLead;
+  w2.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
+  w2.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
+  w2.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
   void resolveOpenTriggersOnLoad(environmentId2);
   initReview();
 })();

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -323,15 +323,13 @@
       el.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`;
       document.head.appendChild(el);
       win.gtag("js", /* @__PURE__ */ new Date());
-      win.gtag("config", measurementId);
     }
+    win.gtag("config", measurementId, { send_page_view: false });
   };
   var ensureLintrk = (partnerId) => {
     const win = w();
     if (!win.lintrk) {
       win._linkedin_partner_id = partnerId;
-      win._linkedin_data_partner_ids = win._linkedin_data_partner_ids || [];
-      win._linkedin_data_partner_ids.push(partnerId);
       const l = win.lintrk = function(a, b) {
         l.q.push([a, b]);
       };
@@ -340,6 +338,10 @@
       el.async = true;
       el.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
       document.head.appendChild(el);
+    }
+    win._linkedin_data_partner_ids = win._linkedin_data_partner_ids || [];
+    if (!win._linkedin_data_partner_ids.includes(partnerId)) {
+      win._linkedin_data_partner_ids.push(partnerId);
     }
   };
   var fireConversion = (provider, event, ctx) => {
@@ -360,7 +362,10 @@
           return true;
         case "ga4":
           ensureGtag(event.measurement_id);
-          win.gtag("event", event.event_name, { transaction_id: ctx.response_id });
+          win.gtag("event", event.event_name, {
+            transaction_id: ctx.response_id,
+            send_to: event.measurement_id
+          });
           return true;
         case "linkedin":
           ensureLintrk(event.partner_id);

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -276,10 +276,150 @@
     };
   }
 
+  // src/conversions/providers.ts
+  var w = () => window;
+  var ensureTwq = (pixelId) => {
+    const win = w();
+    if (!win.twq) {
+      const s = win.twq = function(...args) {
+        s.exe ? s.exe.apply(s, args) : s.queue.push(args);
+      };
+      s.version = "1.1";
+      s.queue = [];
+      const el = document.createElement("script");
+      el.async = true;
+      el.src = "https://static.ads-twitter.com/uwt.js";
+      document.head.appendChild(el);
+    }
+    win.twq("config", pixelId);
+  };
+  var ensureFbq = (pixelId) => {
+    const win = w();
+    if (!win.fbq) {
+      const n = win.fbq = function(...args) {
+        n.callMethod ? n.callMethod.apply(n, args) : n.queue.push(args);
+      };
+      if (!win._fbq) win._fbq = n;
+      n.push = n;
+      n.loaded = true;
+      n.version = "2.0";
+      n.queue = [];
+      const el = document.createElement("script");
+      el.async = true;
+      el.src = "https://connect.facebook.net/en_US/fbevents.js";
+      document.head.appendChild(el);
+    }
+    win.fbq("init", pixelId);
+  };
+  var ensureGtag = (measurementId) => {
+    const win = w();
+    if (!win.gtag) {
+      win.dataLayer = win.dataLayer || [];
+      win.gtag = function(...args) {
+        win.dataLayer.push(args);
+      };
+      const el = document.createElement("script");
+      el.async = true;
+      el.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`;
+      document.head.appendChild(el);
+      win.gtag("js", /* @__PURE__ */ new Date());
+      win.gtag("config", measurementId);
+    }
+  };
+  var ensureLintrk = (partnerId) => {
+    const win = w();
+    if (!win.lintrk) {
+      win._linkedin_partner_id = partnerId;
+      win._linkedin_data_partner_ids = win._linkedin_data_partner_ids || [];
+      win._linkedin_data_partner_ids.push(partnerId);
+      const l = win.lintrk = function(a, b) {
+        l.q.push([a, b]);
+      };
+      l.q = [];
+      const el = document.createElement("script");
+      el.async = true;
+      el.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+      document.head.appendChild(el);
+    }
+  };
+  var fireConversion = (provider, event, ctx) => {
+    const win = w();
+    try {
+      switch (provider) {
+        case "x":
+          ensureTwq(event.pixel_id);
+          win.twq("event", event.event_id, {
+            conversion_id: ctx.response_id,
+            ...ctx.twclid ? { twclid: ctx.twclid } : {},
+            ...ctx.email ? { email_address: ctx.email } : {}
+          });
+          return true;
+        case "meta":
+          ensureFbq(event.pixel_id);
+          win.fbq("track", event.event_name, {}, { eventID: ctx.response_id });
+          return true;
+        case "ga4":
+          ensureGtag(event.measurement_id);
+          win.gtag("event", event.event_name, { transaction_id: ctx.response_id });
+          return true;
+        case "linkedin":
+          ensureLintrk(event.partner_id);
+          win.lintrk("track", { conversion_id: event.conversion_id });
+          return true;
+        default:
+          return false;
+      }
+    } catch {
+      return false;
+    }
+  };
+
+  // src/conversions/conversion-listener.ts
+  var CONVERSION_MESSAGE_TYPE = "surface:conversion";
+  var CONVERSION_ACK_TYPE = "surface:conversion:ack";
+  var VALID_PROVIDERS = ["x", "meta", "ga4", "linkedin"];
+  var firedIds = /* @__PURE__ */ new Set();
+  var isConversionMessage = (data) => !!data && data.type === CONVERSION_MESSAGE_TYPE && typeof data.id === "string" && VALID_PROVIDERS.includes(data.provider) && !!data.event && typeof data.response_id === "string";
+  var handleConversionMessage = (event, log2) => {
+    const data = event.data;
+    if (!isConversionMessage(data)) return;
+    const ack = () => {
+      try {
+        event.source?.postMessage(
+          { type: CONVERSION_ACK_TYPE, id: data.id },
+          event.origin
+        );
+      } catch {
+      }
+    };
+    if (firedIds.has(data.id)) {
+      ack();
+      return;
+    }
+    firedIds.add(data.id);
+    const fired = fireConversion(data.provider, data.event, {
+      response_id: data.response_id,
+      email: data.email,
+      twclid: data.twclid,
+      fbclid: data.fbclid,
+      gclid: data.gclid,
+      li_fat_id: data.li_fat_id
+    });
+    log2.info({
+      message: "Conversion handled",
+      response: { provider: data.provider, responseId: data.response_id, fired }
+    });
+    ack();
+  };
+
   // src/store/message-listener.ts
   function initializeMessageListener(store) {
     const handleMessage = (event) => {
       if (!event.origin || !SURFACE_DOMAINS.includes(event.origin)) {
+        return;
+      }
+      if (event.data?.type === "surface:conversion") {
+        handleConversionMessage(event, store.log);
         return;
       }
       if (event.data.type === "SEND_DATA") {
@@ -1960,8 +2100,8 @@
     }
   }
   async function fetchOpenTriggersMap(environmentId3) {
-    const w2 = window;
-    if (w2.__SURFACE_OPEN_TRIGGERS_MAP) return w2.__SURFACE_OPEN_TRIGGERS_MAP;
+    const w3 = window;
+    if (w3.__SURFACE_OPEN_TRIGGERS_MAP) return w3.__SURFACE_OPEN_TRIGGERS_MAP;
     const sessionKey = SESSION_PREFIX + environmentId3;
     try {
       const cached2 = sessionStorage.getItem(sessionKey);
@@ -1973,7 +2113,7 @@
       }
     } catch {
     }
-    const base = w2.__SURFACE_OPEN_TRIGGERS_BASE || EXTERNAL_FORM_API;
+    const base = w3.__SURFACE_OPEN_TRIGGERS_BASE || EXTERNAL_FORM_API;
     const response = await fetch(`${base}/environments/${encodeURIComponent(environmentId3)}/open-triggers`);
     if (!response.ok) return null;
     const json = await response.json();
@@ -2220,14 +2360,14 @@
   var environmentId2 = getSiteIdFromScript(scriptTag);
   setEnvironmentId(environmentId2);
   var SurfaceTagStore = new SurfaceStore(environmentId2);
-  var w = window;
-  w.SurfaceEmbed = SurfaceEmbed;
-  w.SurfaceExternalForm = SurfaceExternalForm;
-  w.SurfaceTagStore = SurfaceTagStore;
-  w.SurfaceIdentifyLead = identifyLead;
-  w.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
-  w.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
-  w.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
+  var w2 = window;
+  w2.SurfaceEmbed = SurfaceEmbed;
+  w2.SurfaceExternalForm = SurfaceExternalForm;
+  w2.SurfaceTagStore = SurfaceTagStore;
+  w2.SurfaceIdentifyLead = identifyLead;
+  w2.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
+  w2.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
+  w2.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
   void resolveOpenTriggersOnLoad(environmentId2);
   initReview();
 })();

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -323,15 +323,13 @@
       el.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`;
       document.head.appendChild(el);
       win.gtag("js", /* @__PURE__ */ new Date());
-      win.gtag("config", measurementId);
     }
+    win.gtag("config", measurementId, { send_page_view: false });
   };
   var ensureLintrk = (partnerId) => {
     const win = w();
     if (!win.lintrk) {
       win._linkedin_partner_id = partnerId;
-      win._linkedin_data_partner_ids = win._linkedin_data_partner_ids || [];
-      win._linkedin_data_partner_ids.push(partnerId);
       const l = win.lintrk = function(a, b) {
         l.q.push([a, b]);
       };
@@ -340,6 +338,10 @@
       el.async = true;
       el.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
       document.head.appendChild(el);
+    }
+    win._linkedin_data_partner_ids = win._linkedin_data_partner_ids || [];
+    if (!win._linkedin_data_partner_ids.includes(partnerId)) {
+      win._linkedin_data_partner_ids.push(partnerId);
     }
   };
   var fireConversion = (provider, event, ctx) => {
@@ -360,7 +362,10 @@
           return true;
         case "ga4":
           ensureGtag(event.measurement_id);
-          win.gtag("event", event.event_name, { transaction_id: ctx.response_id });
+          win.gtag("event", event.event_name, {
+            transaction_id: ctx.response_id,
+            send_to: event.measurement_id
+          });
           return true;
         case "linkedin":
           ensureLintrk(event.partner_id);


### PR DESCRIPTION
## What changed
Adds a **parent-page ad-conversion listener** to the embed tag. Previously the tag had no pixel-firing code at all; ad pixels only fired inside the form iframe. This lets the form drive first-party conversion firing on the customer's own page.

- `src/conversions/providers.ts` — X / Meta / GA4 / LinkedIn firing. Each `ensure*` runs the vendor bootstrap only if the global (`twq`/`fbq`/`gtag`/`lintrk`) isn't already present, so we never double-inject over a pixel the customer already runs. Mirrors the in-frame firing in surface_forms (`fireConversion.ts`) — keep the two in sync.
- `src/conversions/conversion-listener.ts` — validates a `surface:conversion` message, fires the pixel in this (parent) page, dedupes by message id, and acks (`surface:conversion:ack`) so the iframe doesn't also fire in-frame.
- Wired into the existing `initializeMessageListener`, reusing its `SURFACE_DOMAINS` origin check.

Payloads (per spec): `twq('event', event_id, {conversion_id, twclid, email_address})`, `fbq('track', name, {}, {eventID})`, `gtag('event', name, {transaction_id})`, `lintrk('track', {conversion_id})`. `responseId` is the dedupe key on every provider; click IDs passed through explicitly (never campaign info).

## Why
Companion to **trysurface/surface_forms#4831** — the form iframe evaluates the rules and postMessages here; this side fires the pixel in first-party context so events attribute to the customer's domain.

## Risk / rollback
Inert until forms start sending `surface:conversion` messages — safe to ship before the forms PR. All firing is best-effort (try/catch, silent on ad blockers). Rebuilt bundle (`surface_tag.js` / `surface_embed_v1.js`) is included. **After merge, purge jsDelivr** (`https://purge.jsdelivr.net/gh/trysurface/scripts@latest/surface_tag.min.js`) or the change lags ~12h.

## Validation
- `tsc --noEmit` clean; `pnpm build` succeeds; `surface:conversion` present in the built bundle.
- Full parent↔iframe acceptance run via a local embed harness: in progress.

## Scope note
Origin acceptance reuses the tag's `SURFACE_DOMAINS` allowlist, so this covers standard `forms.withsurface.com` embeds. Custom-domain form iframes have a non-Surface origin and are not handled in v1 (a broader tag-origin change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY9gTkxeocTfcy93ASkXtL
