### PR TITLE
[SURF-1546] feat(conversions): fire the OpenAI Ads pixel

### DIFF
--- a/src/conversions/conversion-listener.ts
+++ b/src/conversions/conversion-listener.ts
@@ -5,7 +5,7 @@ import { fireConversion, type ConversionProvider } from "./providers";
 const CONVERSION_MESSAGE_TYPE = "surface:conversion";
 const CONVERSION_ACK_TYPE = "surface:conversion:ack";
 
-const VALID_PROVIDERS: ConversionProvider[] = ["x", "meta", "ga4", "linkedin"];
+const VALID_PROVIDERS: ConversionProvider[] = ["x", "meta", "openai", "ga4", "linkedin"];
 
 // Idempotency: a form may retry a send; only fire once per message id.
 const firedIds = new Set<string>();

--- a/src/conversions/providers.ts
+++ b/src/conversions/providers.ts
@@ -6,11 +6,11 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export type ConversionProvider = "x" | "meta" | "ga4" | "linkedin";
+export type ConversionProvider = "x" | "meta" | "openai" | "ga4" | "linkedin";
 
 export type ConversionEventPayload =
   | { event_id: string; pixel_id: string } // x
-  | { pixel_id: string; event_name: string } // meta
+  | { pixel_id: string; event_name: string } // meta / openai
   | { measurement_id: string; event_name: string } // ga4
   | { partner_id: string; conversion_id: string }; // linkedin
 
@@ -58,6 +58,21 @@ const ensureFbq = (pixelId: string) => {
     document.head.appendChild(el);
   }
   win.fbq("init", pixelId);
+};
+
+const ensureOaiq = (pixelId: string) => {
+  const win = w();
+  if (!win.oaiq) {
+    const q: any = (win.oaiq = function (...args: any[]) {
+      q.q.push(args);
+    });
+    q.q = [];
+    const el = document.createElement("script");
+    el.async = true;
+    el.src = "https://bzrcdn.openai.com/sdk/oaiq.min.js";
+    document.head.appendChild(el);
+  }
+  win.oaiq("init", { pixelId });
 };
 
 const ensureGtag = (measurementId: string) => {
@@ -121,6 +136,11 @@ export const fireConversion = (
       case "meta":
         ensureFbq(event.pixel_id);
         win.fbq("track", event.event_name, {}, { eventID: ctx.response_id });
+        return true;
+      case "openai":
+        ensureOaiq(event.pixel_id);
+        // event_id is the platform dedupe key (matches browser + server sends).
+        win.oaiq("measure", event.event_name, { type: "customer_action" }, { event_id: ctx.response_id });
         return true;
       case "ga4":
         ensureGtag(event.measurement_id);

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -314,6 +314,20 @@
     }
     win.fbq("init", pixelId);
   };
+  var ensureOaiq = (pixelId) => {
+    const win = w();
+    if (!win.oaiq) {
+      const q = win.oaiq = function(...args) {
+        q.q.push(args);
+      };
+      q.q = [];
+      const el = document.createElement("script");
+      el.async = true;
+      el.src = "https://bzrcdn.openai.com/sdk/oaiq.min.js";
+      document.head.appendChild(el);
+    }
+    win.oaiq("init", { pixelId });
+  };
   var ensureGtag = (measurementId) => {
     const win = w();
     if (!win.gtag) {
@@ -363,6 +377,10 @@
           ensureFbq(event.pixel_id);
           win.fbq("track", event.event_name, {}, { eventID: ctx.response_id });
           return true;
+        case "openai":
+          ensureOaiq(event.pixel_id);
+          win.oaiq("measure", event.event_name, { type: "customer_action" }, { event_id: ctx.response_id });
+          return true;
         case "ga4":
           ensureGtag(event.measurement_id);
           win.gtag("event", event.event_name, {
@@ -385,7 +403,7 @@
   // src/conversions/conversion-listener.ts
   var CONVERSION_MESSAGE_TYPE = "surface:conversion";
   var CONVERSION_ACK_TYPE = "surface:conversion:ack";
-  var VALID_PROVIDERS = ["x", "meta", "ga4", "linkedin"];
+  var VALID_PROVIDERS = ["x", "meta", "openai", "ga4", "linkedin"];
   var firedIds = /* @__PURE__ */ new Set();
   var isConversionMessage = (data) => !!data && data.type === CONVERSION_MESSAGE_TYPE && typeof data.id === "string" && VALID_PROVIDERS.includes(data.provider) && !!data.event && typeof data.response_id === "string";
   var handleConversionMessage = (event, log2) => {

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -314,6 +314,20 @@
     }
     win.fbq("init", pixelId);
   };
+  var ensureOaiq = (pixelId) => {
+    const win = w();
+    if (!win.oaiq) {
+      const q = win.oaiq = function(...args) {
+        q.q.push(args);
+      };
+      q.q = [];
+      const el = document.createElement("script");
+      el.async = true;
+      el.src = "https://bzrcdn.openai.com/sdk/oaiq.min.js";
+      document.head.appendChild(el);
+    }
+    win.oaiq("init", { pixelId });
+  };
   var ensureGtag = (measurementId) => {
     const win = w();
     if (!win.gtag) {
@@ -363,6 +377,10 @@
           ensureFbq(event.pixel_id);
           win.fbq("track", event.event_name, {}, { eventID: ctx.response_id });
           return true;
+        case "openai":
+          ensureOaiq(event.pixel_id);
+          win.oaiq("measure", event.event_name, { type: "customer_action" }, { event_id: ctx.response_id });
+          return true;
         case "ga4":
           ensureGtag(event.measurement_id);
           win.gtag("event", event.event_name, {
@@ -385,7 +403,7 @@
   // src/conversions/conversion-listener.ts
   var CONVERSION_MESSAGE_TYPE = "surface:conversion";
   var CONVERSION_ACK_TYPE = "surface:conversion:ack";
-  var VALID_PROVIDERS = ["x", "meta", "ga4", "linkedin"];
+  var VALID_PROVIDERS = ["x", "meta", "openai", "ga4", "linkedin"];
   var firedIds = /* @__PURE__ */ new Set();
   var isConversionMessage = (data) => !!data && data.type === CONVERSION_MESSAGE_TYPE && typeof data.id === "string" && VALID_PROVIDERS.includes(data.provider) && !!data.event && typeof data.response_id === "string";
   var handleConversionMessage = (event, log2) => {


### PR DESCRIPTION
Companion to surface_forms #5094. Fires the **OpenAI Ads** pixel from the parent embed tag (first-party context), mirroring the in-frame firing in `surface_forms` — the two paths stay in sync.

## Changes
- `providers.ts`: `openai` added to `ConversionProvider`; `ensureOaiq` bootstraps the `oaiq` SDK (`bzrcdn.openai.com/sdk/oaiq.min.js`) only if the global isn't already present, then `oaiq("init", {pixelId})`. Fire path calls `oaiq("measure", event_name, {type:"customer_action"}, {event_id: response_id})` — `event_id` is the dedupe key.
- `conversion-listener.ts`: `openai` added to `VALID_PROVIDERS`.

Payload shape reuses the Meta variant (`{pixel_id, event_name}`), so no wire-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VUdEBjARoRAXvcVtaCS2N