### PR TITLE
[SURF-1901] feat(consent): relay host consent to Surface form iframes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,24 @@ No automated tests, linter, or CI pipeline. Testing is manual and browser-based.
 
 ### PostMessage Protocol
 
-- **To iframe:** `STORE_UPDATE` (cookies, URL params, partial fill data), `LEAD_DATA_UPDATE` (leadId, sessionId, fingerprint)
-- **From iframe:** `SEND_DATA` (iframe requests current store data)
+- **To iframe:** `STORE_UPDATE` (cookies, URL params, partial fill data), `LEAD_DATA_UPDATE` (leadId, sessionId, fingerprint), `surface:consent` (which third-party categories the visitor consented to)
+- **From iframe:** `SEND_DATA` (iframe requests current store data), `surface:conversion` (iframe asks the parent to fire an ad pixel first-party)
+
+### Consent (`src/consent/`)
+
+Forms whose Privacy settings put a category on "On consent" load no scripts for
+it until the host page reports the visitor's answer:
+
+```js
+window.SurfaceSetConsent({ adTracking: true, surfaceAnalytics: true });
+```
+
+`consent.ts` holds the answer in module state and notifies `src/index.ts`, which
+relays `surface:consent` to every Surface iframe (and re-sends it on each
+`SEND_DATA` handshake, for forms that mount after the banner was answered).
+Omitted categories count as not granted. The categories mirror the form-render
+gate in `surface_forms` (`lib/client/thirdParty/`) — keep the message shape in
+sync with its `hostConsent.ts`.
 
 ### Key APIs
 

--- a/src/consent/consent.test.ts
+++ b/src/consent/consent.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getSurfaceConsent,
+  onSurfaceConsentChange,
+  setSurfaceConsent,
+} from "./consent";
+
+describe("surface consent", () => {
+  beforeEach(() => {
+    onSurfaceConsentChange(() => {});
+  });
+
+  it("reports nothing granted until the page answers", () => {
+    // Module state, so this only holds before the first setSurfaceConsent call.
+    expect(getSurfaceConsent()).toBe(null);
+  });
+
+  it("normalises a partial answer — omitted categories are not granted", () => {
+    setSurfaceConsent({ adTracking: true });
+    expect(getSurfaceConsent()).toEqual({
+      adTracking: true,
+      surfaceAnalytics: false,
+    });
+  });
+
+  it("ignores non-boolean values", () => {
+    setSurfaceConsent({ adTracking: "yes" as unknown as boolean });
+    expect(getSurfaceConsent()?.adTracking).toBe(false);
+  });
+
+  it("lets a later answer withdraw consent", () => {
+    setSurfaceConsent({ adTracking: true, surfaceAnalytics: true });
+    setSurfaceConsent({ adTracking: false, surfaceAnalytics: true });
+    expect(getSurfaceConsent()).toEqual({
+      adTracking: false,
+      surfaceAnalytics: true,
+    });
+  });
+
+  it("notifies the relay on every answer", () => {
+    const onChange = vi.fn();
+    onSurfaceConsentChange(onChange);
+
+    setSurfaceConsent({ adTracking: true });
+    setSurfaceConsent({ adTracking: false });
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/consent/consent.ts
+++ b/src/consent/consent.ts
@@ -1,0 +1,41 @@
+// Wire contract with the iframe (surface_forms form-render `hostConsent.ts`).
+// Keep in sync.
+export const SURFACE_CONSENT_MESSAGE_TYPE = "surface:consent";
+
+/**
+ * Categories of third-party calls a Surface form can be told to wait for. They
+ * mirror the form's Privacy settings: a category set to "On consent" there stays
+ * off until this page reports it as granted.
+ */
+export interface SurfaceConsent {
+  adTracking: boolean;
+  surfaceAnalytics: boolean;
+}
+
+let consent: SurfaceConsent | null = null;
+let onChange: (() => void) | null = null;
+
+/** Null until the page has answered — forms treat that as nothing granted. */
+export const getSurfaceConsent = (): SurfaceConsent | null => consent;
+
+export const onSurfaceConsentChange = (callback: () => void): void => {
+  onChange = callback;
+};
+
+/**
+ * Public API — call from a consent banner once the visitor answers:
+ *
+ * ```js
+ * window.SurfaceSetConsent({ adTracking: true, surfaceAnalytics: true });
+ * ```
+ *
+ * Omitted categories count as not granted. Calling again with `false` stops
+ * further tracking, but cannot unload vendor scripts a form already started.
+ */
+export const setSurfaceConsent = (granted: Partial<SurfaceConsent>): void => {
+  consent = {
+    adTracking: granted?.adTracking === true,
+    surfaceAnalytics: granted?.surfaceAnalytics === true,
+  };
+  onChange?.();
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   setEnvironmentId,
 } from "./lead/identify";
 import { SurfaceStore } from "./store/store";
+import { onSurfaceConsentChange, setSurfaceConsent } from "./consent/consent";
 import { SurfaceExternalForm } from "./external-form/external-form";
 import { SurfaceEmbed } from "./embed/embed";
 import { resolveOpenTriggersOnLoad } from "./open-triggers/open-triggers";
@@ -29,6 +30,15 @@ w.SurfaceIdentifyLead = identifyLead;
 w.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
 w.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
 w.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
+w.SurfaceSetConsent = setSurfaceConsent;
+
+// Relay a consent answer to the forms on the page. The store push goes with it
+// so a form that was blocked until now still gets the parent URL params it
+// needs to fire conversions in first-party context.
+onSurfaceConsentChange(() => {
+  SurfaceTagStore.sendConsentToIframes();
+  SurfaceTagStore.sendPayloadToIframes("STORE_UPDATE");
+});
 
 // Auto-open a form when the host URL carries a configured `?<slug>=true` param.
 // Fire-and-forget; only touches the network when params are present.

--- a/src/store/message-listener.test.ts
+++ b/src/store/message-listener.test.ts
@@ -16,6 +16,7 @@ const FORMS_ORIGIN = "https://forms.withsurface.com";
 const makeStore = () =>
   ({
     sendPayloadToIframes: vi.fn(),
+    sendConsentToIframes: vi.fn(),
     clearUserJourney: vi.fn(),
     log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   }) as unknown as SurfaceStore;
@@ -46,6 +47,15 @@ describe("initializeMessageListener", () => {
     dispatch({ type: "SEND_DATA", sender: "surface_form" });
 
     expect(store.sendPayloadToIframes).toHaveBeenCalledWith("STORE_UPDATE");
+  });
+
+  it("re-sends consent on the handshake, so a late-mounting form learns the page's answer", () => {
+    const store = makeStore();
+    initializeMessageListener(store);
+
+    dispatch({ type: "SEND_DATA", sender: "surface_form" });
+
+    expect(store.sendConsentToIframes).toHaveBeenCalledTimes(1);
   });
 
   it("with an environment id: pushes STORE_UPDATE, identifies, then pushes LEAD_DATA_UPDATE", async () => {

--- a/src/store/message-listener.ts
+++ b/src/store/message-listener.ts
@@ -17,6 +17,8 @@ export function initializeMessageListener(store: SurfaceStore): void {
 
     if (event.data.type === "SEND_DATA") {
       store.sendPayloadToIframes("STORE_UPDATE");
+      // A form that booted after the banner was answered learns consent here.
+      store.sendConsentToIframes();
 
       const envId = getEnvironmentId();
       if (envId) {

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -4,6 +4,7 @@ import { identifyLead, getLeadDataWithTTL } from "../lead/identify";
 import { initializeUserJourneyTracking, updateUserJourneyOnRouteChange } from "./user-journey";
 import { onRouteChange } from "../utils/route-observer";
 import type { LeadData } from "../types";
+import { setSurfaceConsent } from "../consent/consent";
 
 vi.mock("./message-listener", () => ({
   initializeMessageListener: vi.fn(),
@@ -175,6 +176,35 @@ describe("SurfaceStore postMessage protocol", () => {
 
     expect(surfacePost).toHaveBeenCalledWith(
       expect.objectContaining({ type: "STORE_UPDATE", sender: "surface_tag" }),
+      "https://forms.withsurface.com"
+    );
+    expect(otherPost).not.toHaveBeenCalled();
+  });
+
+  it("relays consent only to Surface iframes, and only once the page has answered", () => {
+    const surfaceIframe = addIframe(SURFACE_IFRAME_SRC);
+    const otherIframe = addIframe("https://example.com/embed");
+    const store = new SurfaceStore(null);
+
+    const surfacePost = vi
+      .spyOn(surfaceIframe.contentWindow as Window, "postMessage")
+      .mockImplementation(() => {});
+    const otherPost = vi
+      .spyOn(otherIframe.contentWindow as Window, "postMessage")
+      .mockImplementation(() => {});
+
+    store.sendConsentToIframes();
+    expect(surfacePost).not.toHaveBeenCalled();
+
+    setSurfaceConsent({ adTracking: true });
+    store.sendConsentToIframes();
+
+    expect(surfacePost).toHaveBeenCalledWith(
+      {
+        type: "surface:consent",
+        sender: "surface_tag",
+        consent: { adTracking: true, surfaceAnalytics: false },
+      },
       "https://forms.withsurface.com"
     );
     expect(otherPost).not.toHaveBeenCalled();

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,8 @@
 import { VALID_EMBED_TYPES } from "../constants";
+import {
+  getSurfaceConsent,
+  SURFACE_CONSENT_MESSAGE_TYPE,
+} from "../consent/consent";
 import { isDebugMode } from "../utils/debug";
 import { createLogger } from "../utils/logger";
 import { parseCookies } from "../utils/cookies";
@@ -163,17 +167,38 @@ export class SurfaceStore {
     const target = iframe || document.querySelector<HTMLIFrameElement>("#surface-iframe");
     if (!target) return;
 
+    this.postToSurfaceIframe(target, {
+      type,
+      payload: this.getPayload(),
+      sender: "surface_tag",
+    });
+  }
+
+  private postToSurfaceIframe(target: HTMLIFrameElement, message: unknown): void {
     try {
       const targetOrigin = new URL(target.src).origin;
       if (!this.surfaceDomains.includes(targetOrigin)) return;
 
-      target.contentWindow?.postMessage(
-        { type, payload: this.getPayload(), sender: "surface_tag" },
-        targetOrigin
-      );
+      target.contentWindow?.postMessage(message, targetOrigin);
     } catch {
       // Ignore invalid iframe URLs.
     }
+  }
+
+  // Relays the page's consent answer to every Surface form on it. Forms with a
+  // category set to "On consent" stay dark until this arrives, so it is also
+  // re-sent on each SEND_DATA handshake for frames that mount later.
+  sendConsentToIframes(): void {
+    const consent = getSurfaceConsent();
+    if (!consent) return;
+
+    document.querySelectorAll("iframe").forEach((iframe) =>
+      this.postToSurfaceIframe(iframe, {
+        type: SURFACE_CONSENT_MESSAGE_TYPE,
+        sender: "surface_tag",
+        consent,
+      })
+    );
   }
 
   getUrlParams(): Record<string, string> {

--- a/surface_embed_v1.js
+++ b/surface_embed_v1.js
@@ -216,6 +216,22 @@
     return null;
   }
 
+  // src/consent/consent.ts
+  var SURFACE_CONSENT_MESSAGE_TYPE = "surface:consent";
+  var consent = null;
+  var onChange = null;
+  var getSurfaceConsent = () => consent;
+  var onSurfaceConsentChange = (callback) => {
+    onChange = callback;
+  };
+  var setSurfaceConsent = (granted) => {
+    consent = {
+      adTracking: granted?.adTracking === true,
+      surfaceAnalytics: granted?.surfaceAnalytics === true
+    };
+    onChange?.();
+  };
+
   // src/utils/debug.ts
   var cached = null;
   function isDebugMode() {
@@ -496,6 +512,7 @@
       }
       if (event.data.type === "SEND_DATA") {
         store.sendPayloadToIframes("STORE_UPDATE");
+        store.sendConsentToIframes();
         const envId = getEnvironmentId();
         if (envId) {
           const identify = store.config?.customOrigin ? identifyLead(envId, store.config) : identifyLead(envId);
@@ -756,15 +773,33 @@
     notifyIframe(iframe, type) {
       const target = iframe || document.querySelector("#surface-iframe");
       if (!target) return;
+      this.postToSurfaceIframe(target, {
+        type,
+        payload: this.getPayload(),
+        sender: "surface_tag"
+      });
+    }
+    postToSurfaceIframe(target, message) {
       try {
         const targetOrigin = new URL(target.src).origin;
         if (!this.surfaceDomains.includes(targetOrigin)) return;
-        target.contentWindow?.postMessage(
-          { type, payload: this.getPayload(), sender: "surface_tag" },
-          targetOrigin
-        );
+        target.contentWindow?.postMessage(message, targetOrigin);
       } catch {
       }
+    }
+    // Relays the page's consent answer to every Surface form on it. Forms with a
+    // category set to "On consent" stay dark until this arrives, so it is also
+    // re-sent on each SEND_DATA handshake for frames that mount later.
+    sendConsentToIframes() {
+      const consent2 = getSurfaceConsent();
+      if (!consent2) return;
+      document.querySelectorAll("iframe").forEach(
+        (iframe) => this.postToSurfaceIframe(iframe, {
+          type: SURFACE_CONSENT_MESSAGE_TYPE,
+          sender: "surface_tag",
+          consent: consent2
+        })
+      );
     }
     getUrlParams() {
       return getUrlParams();
@@ -2473,6 +2508,11 @@
   w2.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
   w2.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
   w2.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
+  w2.SurfaceSetConsent = setSurfaceConsent;
+  onSurfaceConsentChange(() => {
+    SurfaceTagStore.sendConsentToIframes();
+    SurfaceTagStore.sendPayloadToIframes("STORE_UPDATE");
+  });
   void resolveOpenTriggersOnLoad(environmentId2, runtimeConfig2);
   initReview();
 })();

--- a/surface_tag.js
+++ b/surface_tag.js
@@ -216,6 +216,22 @@
     return null;
   }
 
+  // src/consent/consent.ts
+  var SURFACE_CONSENT_MESSAGE_TYPE = "surface:consent";
+  var consent = null;
+  var onChange = null;
+  var getSurfaceConsent = () => consent;
+  var onSurfaceConsentChange = (callback) => {
+    onChange = callback;
+  };
+  var setSurfaceConsent = (granted) => {
+    consent = {
+      adTracking: granted?.adTracking === true,
+      surfaceAnalytics: granted?.surfaceAnalytics === true
+    };
+    onChange?.();
+  };
+
   // src/utils/debug.ts
   var cached = null;
   function isDebugMode() {
@@ -496,6 +512,7 @@
       }
       if (event.data.type === "SEND_DATA") {
         store.sendPayloadToIframes("STORE_UPDATE");
+        store.sendConsentToIframes();
         const envId = getEnvironmentId();
         if (envId) {
           const identify = store.config?.customOrigin ? identifyLead(envId, store.config) : identifyLead(envId);
@@ -756,15 +773,33 @@
     notifyIframe(iframe, type) {
       const target = iframe || document.querySelector("#surface-iframe");
       if (!target) return;
+      this.postToSurfaceIframe(target, {
+        type,
+        payload: this.getPayload(),
+        sender: "surface_tag"
+      });
+    }
+    postToSurfaceIframe(target, message) {
       try {
         const targetOrigin = new URL(target.src).origin;
         if (!this.surfaceDomains.includes(targetOrigin)) return;
-        target.contentWindow?.postMessage(
-          { type, payload: this.getPayload(), sender: "surface_tag" },
-          targetOrigin
-        );
+        target.contentWindow?.postMessage(message, targetOrigin);
       } catch {
       }
+    }
+    // Relays the page's consent answer to every Surface form on it. Forms with a
+    // category set to "On consent" stay dark until this arrives, so it is also
+    // re-sent on each SEND_DATA handshake for frames that mount later.
+    sendConsentToIframes() {
+      const consent2 = getSurfaceConsent();
+      if (!consent2) return;
+      document.querySelectorAll("iframe").forEach(
+        (iframe) => this.postToSurfaceIframe(iframe, {
+          type: SURFACE_CONSENT_MESSAGE_TYPE,
+          sender: "surface_tag",
+          consent: consent2
+        })
+      );
     }
     getUrlParams() {
       return getUrlParams();
@@ -2473,6 +2508,11 @@
   w2.SurfaceSetLeadDataWithTTL = setLeadDataWithTTL;
   w2.SurfaceGetLeadDataWithTTL = getLeadDataWithTTL;
   w2.SurfaceGetSiteIdFromScript = getSiteIdFromScript;
+  w2.SurfaceSetConsent = setSurfaceConsent;
+  onSurfaceConsentChange(() => {
+    SurfaceTagStore.sendConsentToIframes();
+    SurfaceTagStore.sendPayloadToIframes("STORE_UPDATE");
+  });
   void resolveOpenTriggersOnLoad(environmentId2, runtimeConfig2);
   initReview();
 })();

--- a/test/consent.css
+++ b/test/consent.css
@@ -1,0 +1,117 @@
+/* Consent-mode test page: the stand-in cookie banner and its surroundings. */
+
+/* The banner rows below set `display`, which would otherwise win over [hidden]. */
+.cookie-prefs[hidden],
+.consent-status[hidden] {
+  display: none;
+}
+
+.steps {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.7;
+}
+
+.steps li + li {
+  margin-top: 8px;
+}
+
+.note {
+  color: #6b7280;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.filter-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.filter-row code {
+  background: #f5f5f5;
+  border-radius: 4px;
+  flex: 1;
+  overflow-x: auto;
+  padding: 6px 8px;
+  white-space: nowrap;
+}
+
+.consent-iframe {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  height: 600px;
+  width: 100%;
+}
+
+/* Leave room for the fixed banner so it never covers the form. */
+body {
+  padding-bottom: 180px;
+}
+
+.cookie-banner,
+.consent-status {
+  background: #ffffff;
+  border-top: 1px solid #e0e0e0;
+  bottom: 0;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.08);
+  left: 0;
+  position: fixed;
+  right: 0;
+  z-index: 1000;
+}
+
+.cookie-banner-body {
+  align-items: center;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  margin: 0 auto;
+  max-width: 1000px;
+  padding: 20px;
+}
+
+.cookie-copy p {
+  color: #4b5563;
+  font-size: 14px;
+  line-height: 1.6;
+  margin: 4px 0 0;
+}
+
+.cookie-actions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 8px;
+}
+
+.cookie-prefs {
+  align-items: center;
+  border-top: 1px solid #f0f0f0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  margin: 0 auto;
+  max-width: 1000px;
+  padding: 14px 20px;
+}
+
+.cookie-prefs label {
+  align-items: center;
+  display: flex;
+  font-size: 14px;
+  gap: 8px;
+}
+
+.consent-status {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  padding: 14px 20px;
+}
+
+.consent-status span {
+  font-size: 14px;
+  font-weight: 600;
+}

--- a/test/consent.html
+++ b/test/consent.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Consent Mode Test - Surface Form</title>
+    <link rel="stylesheet" href="common.css">
+    <link rel="stylesheet" href="consent.css">
+    <script>
+      // Resolve config before anything loads: in tag mode the script element
+      // needs its site-id and (for a non-production form origin such as a
+      // preview deploy) data-custom-domain set at load time, because the tag
+      // reads them off document.currentScript.
+      (() => {
+        const PRODUCTION_ORIGINS = [
+          "https://forms.withsurface.com",
+          "https://app.withsurface.com",
+          "https://dev.withsurface.com",
+        ];
+        const params = new URLSearchParams(window.location.search);
+        const formSrc = (
+          params.get("formSrc") || "https://dev.withsurface.com/s/cmmv0dvhf0001ju040jfogjrz"
+        ).trim();
+
+        let formOrigin = "";
+        try {
+          formOrigin = new URL(formSrc).origin;
+        } catch {
+          /* reported in the config panel below */
+        }
+
+        const config = {
+          formSrc,
+          formOrigin,
+          siteId: params.get("siteId") || "cllo318mt0003mb08hnp0f5zy",
+          // "tag": the page calls window.SurfaceSetConsent and the tag relays.
+          // "iframe": no tag at all, the page posts to the frame itself.
+          mode: params.get("mode") === "iframe" ? "iframe" : "tag",
+          tagStatus: "not loaded (direct iframe mode)",
+        };
+        window.consentTestConfig = config;
+
+        if (config.mode !== "tag" || !formOrigin) return;
+
+        const script = document.createElement("script");
+        script.src = "../surface_tag.js";
+        script.setAttribute("site-id", config.siteId);
+        // The tag only posts to origins on its allowlist. Production origins are
+        // built in; a preview deploy or custom domain has to be declared.
+        if (!PRODUCTION_ORIGINS.includes(formOrigin)) {
+          script.setAttribute("data-custom-domain", formOrigin);
+          config.customDomain = formOrigin;
+        }
+        document.head.appendChild(script);
+        config.tagStatus = "loaded";
+      })();
+    </script>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Consent Mode Test</h1>
+      <p><a href="index.html">&larr; Back to Test Suite</a></p>
+
+      <div class="config-section">
+        <strong>Configuration:</strong><br>
+
+        <label for="formUrlInput" style="font-weight: 600; margin-top: 8px; display: inline-block;">Form URL:</label><br>
+        <input type="text" id="formUrlInput">
+        <button id="reloadWithForm">Reload</button>
+
+        <hr style="margin: 16px 0; border: none; border-top: 1px solid #e0e0e0;">
+        Consent delivery:
+        <a href="?mode=tag" id="modeTagLink"><code>Surface tag</code></a> ·
+        <a href="?mode=iframe" id="modeIframeLink"><code>Direct iframe</code></a>
+        &mdash; currently <code id="modeLabel"></code><br>
+        Environment ID: <code id="siteIdLabel"></code><br>
+        Custom domain declared to the tag: <code id="customDomainLabel"></code><br>
+        Surface Tag: <code id="tagStatus"></code><br>
+        Debug Mode: <code id="debugMode">false</code> (add <code>?surfaceDebug=true</code> to enable)
+      </div>
+
+      <div class="section">
+        <h2>How to run this test</h2>
+        <ol class="steps">
+          <li>
+            In the form's <strong>Settings &rarr; Privacy</strong> tab, set <em>Ad &amp; conversion tracking</em>
+            (and/or <em>Surface analytics</em>) to <strong>On consent</strong>.
+          </li>
+          <li>
+            Give the form something to block: a GTM container, GA4 measurement ID, Meta Pixel, or HubSpot
+            tracking ID on the other settings tabs. Surface analytics needs nothing configured.
+          </li>
+          <li>
+            Point <code>Form URL</code> above at that form and reload. Open DevTools &rarr; Network and filter on:
+            <div class="filter-row">
+              <code id="vendorFilter">googletagmanager|google-analytics|connect.facebook|facebook.com/tr|hs-scripts|posthog|vercel-scripts</code>
+              <button class="secondary" id="copyFilter">Copy</button>
+            </div>
+          </li>
+          <li>
+            <strong>Before answering the banner:</strong> no requests match. That is the whole point &mdash;
+            the form rendered, but nothing third-party loaded.
+          </li>
+          <li>
+            <strong>Accept in the banner:</strong> the matching vendor requests appear within a second, with no
+            page reload. Reject instead and the filter stays empty.
+          </li>
+        </ol>
+        <p class="note">
+          Withdrawing consent after accepting stops further calls but cannot unload scripts that already
+          started &mdash; reload the page to get back to a clean slate.
+        </p>
+      </div>
+
+      <h2>Events Summary</h2>
+      <div class="events-summary">
+        <div class="summary-card"><div class="summary-count" id="totalEvents">0</div><div class="summary-label">Total Events</div></div>
+        <div class="summary-card"><div class="summary-count" id="sentEvents">0</div><div class="summary-label">Sent to Iframe</div></div>
+        <div class="summary-card"><div class="summary-count" id="receivedEvents">0</div><div class="summary-label">Received from Iframe</div></div>
+        <div class="summary-card"><div class="summary-count" id="storeUpdateEvents">0</div><div class="summary-label">STORE_UPDATE</div></div>
+        <div class="summary-card"><div class="summary-count" id="leadDataEvents">0</div><div class="summary-label">LEAD_DATA_UPDATE</div></div>
+        <div class="summary-card"><div class="summary-count" id="sendDataEvents">0</div><div class="summary-label">SEND_DATA</div></div>
+      </div>
+
+      <h2>Events Log</h2>
+      <div class="button-group">
+        <button class="clear-log" onclick="clearEventLog()">Clear Log</button>
+        <button class="secondary" onclick="exportEvents()">Export Events</button>
+      </div>
+      <div class="events-log" id="eventsLog"></div>
+
+      <div class="section">
+        <h2>Embedded Form</h2>
+        <p class="note">
+          A plain iframe, as a customer would write it. In tag mode the tag finds it on the page and relays
+          consent to it; in direct-iframe mode this page posts to it directly.
+        </p>
+        <iframe id="consentIframe" class="consent-iframe"></iframe>
+      </div>
+    </div>
+
+    <!-- Stand-in for the customer's own cookie banner. -->
+    <div class="cookie-banner" id="cookieBanner">
+      <div class="cookie-banner-body">
+        <div class="cookie-copy">
+          <strong>We use cookies</strong>
+          <p>
+            We&rsquo;d like to use cookies for marketing and analytics. Nothing loads until you choose &mdash;
+            including the tracking on the form below.
+          </p>
+        </div>
+        <div class="cookie-actions">
+          <button class="secondary" id="managePrefs">Manage</button>
+          <button class="secondary" id="rejectAll">Reject all</button>
+          <button id="acceptAll">Accept all</button>
+        </div>
+      </div>
+      <div class="cookie-prefs" id="cookiePrefs" hidden>
+        <label><input type="checkbox" id="prefAdTracking"> Marketing &mdash; <code>adTracking</code></label>
+        <label><input type="checkbox" id="prefSurfaceAnalytics"> Analytics &mdash; <code>surfaceAnalytics</code></label>
+        <button id="savePrefs">Save choices</button>
+      </div>
+    </div>
+
+    <div class="consent-status" id="consentStatus" hidden>
+      <span id="consentStatusText"></span>
+      <button class="secondary" id="changePrefs">Change preferences</button>
+    </div>
+
+    <script src="event-monitor.js"></script>
+    <script src="consent.js"></script>
+  </body>
+</html>

--- a/test/consent.js
+++ b/test/consent.js
@@ -1,0 +1,117 @@
+// Drives the consent-mode test page: renders the config panel, wires the
+// stand-in cookie banner, and delivers the answer the way the chosen embed
+// shape would — window.SurfaceSetConsent (tag relays it) or a postMessage
+// straight to the form frame (no tag on the page).
+
+const config = window.consentTestConfig;
+const iframe = document.getElementById("consentIframe");
+const banner = document.getElementById("cookieBanner");
+const prefs = document.getElementById("cookiePrefs");
+const status = document.getElementById("consentStatus");
+const statusText = document.getElementById("consentStatusText");
+const adTrackingPref = document.getElementById("prefAdTracking");
+const surfaceAnalyticsPref = document.getElementById("prefSurfaceAnalytics");
+
+const text = (id, value) => {
+  document.getElementById(id).textContent = value;
+};
+
+const describe = (consent) =>
+  Object.entries(consent)
+    .map(([category, granted]) => `${category}: ${granted ? "granted" : "denied"}`)
+    .join(", ");
+
+function renderConfig() {
+  document.getElementById("formUrlInput").value = config.formSrc;
+  text("modeLabel", config.mode === "tag" ? "Surface tag" : "Direct iframe (no tag)");
+  text("siteIdLabel", config.siteId);
+  text("customDomainLabel", config.customDomain || "none (production origin)");
+  text("tagStatus", config.tagStatus);
+  text("debugMode", String(window.location.search.includes("surfaceDebug=true")));
+
+  if (!config.formOrigin) {
+    text("tagStatus", "form URL is not a valid absolute URL");
+    return;
+  }
+  iframe.src = config.formSrc;
+}
+
+function reloadWithFormUrl() {
+  const params = new URLSearchParams(window.location.search);
+  params.set("formSrc", document.getElementById("formUrlInput").value.trim());
+  window.location.search = params.toString();
+}
+
+// The one call a real cookie banner would make.
+function deliverConsent(consent) {
+  if (config.mode === "tag") {
+    if (typeof window.SurfaceSetConsent !== "function") {
+      logEvent(
+        { type: "CONSENT_NOT_DELIVERED", sender: "consent_banner", payload: { reason: "surface_tag.js did not load — run `pnpm run build` and serve from the repo root" } },
+        "sent"
+      );
+      return;
+    }
+    window.SurfaceSetConsent(consent);
+    logEvent({ type: "SurfaceSetConsent", sender: "consent_banner", payload: consent }, "sent");
+    return;
+  }
+
+  iframe.contentWindow.postMessage({ type: "surface:consent", consent }, config.formOrigin);
+  logEvent(
+    { type: "surface:consent", sender: "consent_banner", payload: { consent, targetOrigin: config.formOrigin } },
+    "sent"
+  );
+}
+
+function answer(consent) {
+  deliverConsent(consent);
+  adTrackingPref.checked = consent.adTracking;
+  surfaceAnalyticsPref.checked = consent.surfaceAnalytics;
+  banner.hidden = true;
+  status.hidden = false;
+  statusText.textContent = `Consent — ${describe(consent)}`;
+}
+
+function showBanner() {
+  status.hidden = true;
+  banner.hidden = false;
+  prefs.hidden = false;
+}
+
+document.getElementById("reloadWithForm").addEventListener("click", reloadWithFormUrl);
+document.getElementById("managePrefs").addEventListener("click", () => {
+  prefs.hidden = !prefs.hidden;
+});
+document.getElementById("acceptAll").addEventListener("click", () =>
+  answer({ adTracking: true, surfaceAnalytics: true })
+);
+document.getElementById("rejectAll").addEventListener("click", () =>
+  answer({ adTracking: false, surfaceAnalytics: false })
+);
+document.getElementById("savePrefs").addEventListener("click", () =>
+  answer({ adTracking: adTrackingPref.checked, surfaceAnalytics: surfaceAnalyticsPref.checked })
+);
+document.getElementById("changePrefs").addEventListener("click", showBanner);
+document.getElementById("copyFilter").addEventListener("click", (event) => {
+  navigator.clipboard.writeText(document.getElementById("vendorFilter").textContent.trim());
+  event.target.textContent = "Copied";
+  setTimeout(() => (event.target.textContent = "Copy"), 1500);
+});
+
+// event-monitor.js only logs messages from production Surface origins, so log
+// the form frame's own traffic here — it may be a preview deploy or localhost.
+window.addEventListener(
+  "message",
+  (event) => {
+    if (event.origin !== config.formOrigin || !event.data) return;
+    logEvent(
+      { type: event.data.type || "UNKNOWN", payload: event.data.payload || event.data, sender: event.data.sender || "iframe" },
+      "received"
+    );
+  },
+  true
+);
+
+initializeEventMonitoring();
+renderConfig();

--- a/test/index.html
+++ b/test/index.html
@@ -46,6 +46,12 @@
         </div>
 
         <div class="nav-card">
+          <h3>6. Consent Mode</h3>
+          <p>Cookie banner driving a form whose Privacy settings wait for consent, via the tag or a direct iframe.</p>
+          <a href="consent.html" class="nav-link">Test Consent &rarr;</a>
+        </div>
+
+        <div class="nav-card">
           <h3>5. Direct Iframe</h3>
           <p>Customer-embedded iframe with a slow (<code>?tagDelay=3000</code>) or blocked (<code>?noTag=1</code>) tag.</p>
           <a href="direct-iframe.html" class="nav-link">Test Direct Iframe →</a>


### PR DESCRIPTION
Page-side half of per-form consent mode. Pairs with trysurface/surface_forms#5631 (stacked on #5625 → #5624) — **that PR's "On consent" setting does nothing for tag embeds without this one.**

## What changed

A form whose Privacy settings put a category on "On consent" loads no vendor scripts until the embedding page reports the visitor's answer. This adds the API that reports it, plus a test page that exercises the whole path.

- **`src/consent/consent.ts`** (new) — module state plus the public API:

  ```js
  // from your consent banner, once the visitor answers
  window.SurfaceSetConsent({ adTracking: true, surfaceAnalytics: true });
  ```

  Omitted or non-boolean categories count as **not** granted. A later call can withdraw.

- **Relay** — `store.sendConsentToIframes()` posts `{ type: "surface:consent", sender: "surface_tag", consent }` to every Surface iframe, through the same origin allowlist `notifyIframe` already used (extracted as `postToSurfaceIframe`, no behavior change). It is also re-sent on each `SEND_DATA` handshake, so a form that mounts after the banner was answered still learns about it.

- **`src/index.ts`** — exposes `SurfaceSetConsent` and wires the change callback. A `STORE_UPDATE` push rides along with each relay: a form unblocked mid-session still needs the parent URL params to fire conversions in first-party context.

- **`test/consent.html`** (new, linked from the test suite index) — a stand-in cookie banner over a real embedded form:
  - `?mode=tag` (default) delivers through `SurfaceSetConsent` and the tag relays; `?mode=iframe` loads **no tag** and posts `surface:consent` straight to the frame, the way a customer embedding a plain `<iframe>` would.
  - `?formSrc=` points at any form. A non-production origin (preview deploy, custom domain) is declared to the tag via `data-custom-domain` automatically — that is what lets the unmerged #5631 build be tested.
  - Accept all / Reject all / per-category choices, plus *Change preferences* to withdraw. Every delivery is written to the shared events log, and the page carries the DevTools network filter to watch.

- Docs: `CLAUDE.md` gains a Consent section and the protocol list now names `surface:consent` and `surface:conversion`.

Nothing changes for pages that never call the API — no consent is relayed until the first call, and the form side treats absence as not granted.

## Why

Customers with a consent banner had to choose between loading tracking before consent or not at all. The form side can gate the scripts, but only the host page knows what the visitor answered, so it needs a way to say so. Plain `<iframe>` embeds without the tag can post the same message themselves — the settings UI in #5631 hands them that snippet too.

## Risk / rollback

Low. No new listeners, no network calls, no behavior on pages that don't call `SurfaceSetConsent`. The `notifyIframe` refactor is a pure extraction covered by the existing protocol test. `test/` is not part of the build. Revert to roll back.

## Validation

- `pnpm test`: **3 files / 19 tests** green (main: 2 files / 12). New `consent.test.ts` covers normalisation, partial and non-boolean answers, withdrawal, and the change callback; `store.test.ts` gains a case asserting consent reaches Surface iframes only, and only after the page has answered; `message-listener.test.ts` gains one asserting the handshake re-sends it.
- `pnpm run typecheck`: clean.
- `pnpm run build` re-run; `surface_tag.js` / `surface_embed_v1.js` regenerated.
- **Real-browser run of `test/consent.html`** (Playwright, built bundle, form on `dev.withsurface.com`):
  - tag mode, *Accept all* → `{type:"surface:consent",sender:"surface_tag",consent:{adTracking:true,surfaceAnalytics:true}}` relayed to `https://dev.withsurface.com`, followed by `STORE_UPDATE`;
  - `?formSrc=` pointed at the #5631 preview → the preview origin is auto-declared and joins the allowlist, and both messages target it;
  - `?mode=iframe` → no tag loads at all, and *Reject all* then a per-category *Save choices* post `surface:consent` directly to the frame with the form's exact origin as `targetOrigin`;
  - across every run, **zero** messages reached a non-Surface iframe on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cp98sntpeRzPJx9a6Fj3RX